### PR TITLE
Feat board : 게시판 기능 구현 완료 (FE)

### DIFF
--- a/ganoverflow-next/src/app/api/axiosInstanceManager.ts
+++ b/ganoverflow-next/src/app/api/axiosInstanceManager.ts
@@ -18,3 +18,4 @@ export const chatAPI = GenerateAPI("chatbot");
 export const chatPostAPI = GenerateAPI("chatposts");
 export const authAPI = GenerateAPI("auth");
 export const userAPI = GenerateAPI("user");
+export const commentAPI = GenerateAPI("comments");

--- a/ganoverflow-next/src/app/chat/api/chat.ts
+++ b/ganoverflow-next/src/app/chat/api/chat.ts
@@ -25,8 +25,8 @@ export const sendChatPost = async (
   return response;
 };
 
-export const getAllChatPosts = async () => {
-  const response = await GET("chatposts");
+export const getAllChatPostsByUserId = async () => {
+  const response = await GET("chatposts/my-chats");
   return response;
 };
 

--- a/ganoverflow-next/src/app/chat/layout.tsx
+++ b/ganoverflow-next/src/app/chat/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { getAllChatPosts } from "./api/chat";
+import { getAllChatPostsByUserId } from "./api/chat";
 import { chatPostAPI } from "../api/axiosInstanceManager";
 import Link from "next/link";
 
@@ -9,7 +9,7 @@ export default async function Layout({
 }: {
   children: React.ReactNode;
 }) {
-  const chatPosts = await getAllChatPosts();
+  const chatPosts = await getAllChatPostsByUserId();
   // const chatPosts = await chatPostAPI.get("/");
 
   console.log("@@@@@@@@@@@@@@@@@Layout", chatPosts);

--- a/ganoverflow-next/src/app/layout.tsx
+++ b/ganoverflow-next/src/app/layout.tsx
@@ -139,18 +139,18 @@ const Header = (): JSX.Element => {
               <Link
                 href="/"
                 target="_blank"
-                rel="noreferrer"
+                // rel="noreferrer"
                 className="text-[#AEAEB2] font-inter text-sm px-4 py-5 font-semibold"
                 passHref
               >
                 머시기
               </Link>
               <Link
-                href="/"
+                href="/posts"
                 className="text-[#AEAEB2] font-inter text-sm px-4 py-5 font-semibold"
                 passHref
               >
-                커뮤니티
+                게시판
               </Link>
               <Link
                 href="/"

--- a/ganoverflow-next/src/app/posts/[chatPostId]/comments.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/comments.tsx
@@ -1,18 +1,45 @@
 "use client";
 
-import { ChangeEvent, InputHTMLAttributes, useState } from "react";
+import { useState } from "react";
+import { getComments, postComment } from "../api/chatposts";
+import { useAuthDataHook } from "@/app/utils/jwtHooks/getNewAccessToken";
+import { useRouter } from "next/navigation";
 
-export function CommentBox({ comments }: { comments: any }) {
-  const commentCount = comments?.length;
-  const [commentData, setCommentData] = useState<string>("");
+export async function CommentBox({ chatPostId }: { chatPostId: string }) {
+  const authData = useAuthDataHook();
+  const router = useRouter();
+  // const commentCount = comments?.length;
+  const commentCount = 0;
+  const [comments, setComments] = useState([]);
+  const [commentData, setCommentData] = useState("");
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setCommentData(e.target.value);
   };
+
+  const handleSubmit = async () => {
+    if (commentData === "") {
+      alert("댓글을 입력하세요");
+      return;
+    }
+    const res = await postComment(commentData, await authData, chatPostId);
+    if (res.status === 201) {
+      setCommentData("");
+      alert("등록이 완료되었습니다.");
+      router.refresh();
+    } else {
+      console.log("res ", res);
+      alert("등록 실패");
+    }
+  };
+
   return (
     <>
       <div className="comments-totalcount">{`전체 댓글 ${commentCount}개`}</div>
       <div className="comments-commentbox border border-stone-500">
-        {comments}
+        {/* {comments?.map((comment, idx) => {
+          return <div key={idx}>{comment}</div>;
+        })} */}
       </div>
       <div className="comments-write-box flex flex-col">
         <input
@@ -23,7 +50,10 @@ export function CommentBox({ comments }: { comments: any }) {
           placeholder="댓글을 입력해 주세요"
         />
         <div className="flex justify-end">
-          <button className="comment-submit w-32 h-8 bg-indigo-400 rounded-xl">
+          <button
+            className="comment-submit w-32 h-8 bg-indigo-400 rounded-xl"
+            onClick={handleSubmit}
+          >
             등록
           </button>
         </div>

--- a/ganoverflow-next/src/app/posts/[chatPostId]/comments.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/comments.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { ChangeEvent, InputHTMLAttributes, useState } from "react";
+
+export function CommentBox({ comments }: { comments: any }) {
+  const commentCount = comments?.length;
+  const [commentData, setCommentData] = useState<string>("");
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCommentData(e.target.value);
+  };
+  return (
+    <>
+      <div className="comments-totalcount">{`전체 댓글 ${commentCount}개`}</div>
+      <div className="comments-commentbox border border-stone-500">
+        {comments}
+      </div>
+      <div className="comments-write-box flex flex-col">
+        <input
+          name="comment"
+          onChange={handleChange}
+          value={commentData}
+          className="border border-gray-300 w-full h-40 p-2 my-3 bg-gray-600"
+          placeholder="댓글을 입력해 주세요"
+        />
+        <div className="flex justify-end">
+          <button className="comment-submit w-32 h-8 bg-indigo-400 rounded-xl">
+            등록
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/ganoverflow-next/src/app/posts/[chatPostId]/comments.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/comments.tsx
@@ -1,20 +1,30 @@
 "use client";
 
-import { useState } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 import { getComments, postComment } from "../api/chatposts";
 import { useAuthDataHook } from "@/app/utils/jwtHooks/getNewAccessToken";
 import { useRouter } from "next/navigation";
 
-export async function CommentBox({ chatPostId }: { chatPostId: string }) {
+export function CommentBox({
+  chatPostId,
+  comments,
+}: {
+  chatPostId: string;
+  comments: {
+    commentId: number;
+    content: string;
+    createdAt: Date;
+    delYn: string;
+  }[];
+}) {
   const authData = useAuthDataHook();
   const router = useRouter();
-  // const commentCount = comments?.length;
-  const commentCount = 0;
-  const [comments, setComments] = useState([]);
+  const commentCount = comments?.length;
   const [commentData, setCommentData] = useState("");
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setCommentData(e.target.value);
+    console.log(e.target.value);
   };
 
   const handleSubmit = async () => {
@@ -22,7 +32,11 @@ export async function CommentBox({ chatPostId }: { chatPostId: string }) {
       alert("댓글을 입력하세요");
       return;
     }
-    const res = await postComment(commentData, await authData, chatPostId);
+    const res = await postComment(
+      { content: commentData },
+      await authData,
+      chatPostId
+    );
     if (res.status === 201) {
       setCommentData("");
       alert("등록이 완료되었습니다.");
@@ -37,9 +51,13 @@ export async function CommentBox({ chatPostId }: { chatPostId: string }) {
     <>
       <div className="comments-totalcount">{`전체 댓글 ${commentCount}개`}</div>
       <div className="comments-commentbox border border-stone-500">
-        {/* {comments?.map((comment, idx) => {
-          return <div key={idx}>{comment}</div>;
-        })} */}
+        {comments?.map((comment, idx) => {
+          return (
+            <div key={idx} className="border border-1">
+              {comment.content}
+            </div>
+          );
+        })}
       </div>
       <div className="comments-write-box flex flex-col">
         <input

--- a/ganoverflow-next/src/app/posts/[chatPostId]/layout.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/layout.tsx
@@ -1,7 +1,0 @@
-export default function PostDetailLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return <>{children}</>;
-}

--- a/ganoverflow-next/src/app/posts/[chatPostId]/layout.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/layout.tsx
@@ -1,0 +1,7 @@
+export default function PostDetailLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
@@ -1,7 +1,54 @@
+"use client";
+import { useParams } from "next/navigation";
+import { getOneChatPost } from "../api/chatposts";
+import { CommentBox } from "./comments";
+
 export default async function PostDetailPage() {
+  const params = useParams();
+  const chatPostId = params.chatPostId;
+
+  const postData = await getOneChatPost(chatPostId);
+  console.log(postData);
   return (
-    <>
-      <div>title</div>
-    </>
+    <div className="grid">
+      <article className="post-detail-main w-3/5 place-self-center">
+        <div>게시물 보여줘잉</div>
+        <div className="post-title-box w-full border border-x-0 border-green-500 border-t-4 py-5 flex flex-col">
+          <h2 className="post-title text-start px-3 text-3xl text">
+            {postData?.title}
+          </h2>
+          <div className="post-userdate-box flex flex-row">
+            <div className="post-user px-3 border border-0 border-r-2">
+              {postData?.userId?.nickname}
+            </div>
+            <div className="post-date px-3">{`${postData?.createdAt.slice(
+              0,
+              10
+            )} ${postData?.createdAt.slice(11, 19)}`}</div>
+          </div>
+        </div>
+        <div className="post-chat-box min-h-[500px]">
+          {postData?.chatPair
+            ?.sort(
+              (pairOne: any, pairTwo: any) => pairOne.order - pairTwo.order
+            )
+            .map((pair: any, idx: number) => {
+              return (
+                <div key={idx}>
+                  <div>
+                    <div>Q</div>
+                    <div>{pair?.question}</div>
+                  </div>
+                  <div>
+                    <div>A</div>
+                    <div>{pair?.answer}</div>
+                  </div>
+                </div>
+              );
+            })}
+        </div>
+        <CommentBox comments={postData?.comments} />
+      </article>
+    </div>
   );
 }

--- a/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
@@ -1,0 +1,7 @@
+export default async function PostDetailPage() {
+  return (
+    <>
+      <div>title</div>
+    </>
+  );
+}

--- a/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
@@ -8,11 +8,10 @@ export default async function PostDetailPage() {
   const chatPostId = params.chatPostId;
 
   const postData = await getOneChatPost(chatPostId);
-  // console.log(postData);
+  console.log(postData);
   return (
     <div className="grid">
       <article className="post-detail-main w-3/5 place-self-center">
-        <div>게시물 보여줘잉</div>
         <div className="post-title-box w-full border border-x-0 border-green-500 border-t-4 py-5 flex flex-col">
           <h2 className="post-title text-start px-3 text-3xl text">
             {postData?.title}
@@ -47,7 +46,7 @@ export default async function PostDetailPage() {
               );
             })}
         </div>
-        <CommentBox chatPostId={chatPostId} />
+        <CommentBox chatPostId={chatPostId} comments={postData?.comments} />
       </article>
     </div>
   );

--- a/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
@@ -8,7 +8,7 @@ export default async function PostDetailPage() {
   const chatPostId = params.chatPostId;
 
   const postData = await getOneChatPost(chatPostId);
-  console.log(postData);
+  // console.log(postData);
   return (
     <div className="grid">
       <article className="post-detail-main w-3/5 place-self-center">
@@ -47,7 +47,7 @@ export default async function PostDetailPage() {
               );
             })}
         </div>
-        <CommentBox comments={postData?.comments} />
+        <CommentBox chatPostId={chatPostId} />
       </article>
     </div>
   );

--- a/ganoverflow-next/src/app/posts/api/chatposts.ts
+++ b/ganoverflow-next/src/app/posts/api/chatposts.ts
@@ -1,4 +1,6 @@
-import { GET } from "@/app/api/routeModule";
+import { commentAPI } from "@/app/api/axiosInstanceManager";
+import { GenerateAuthHeader, IAuthData } from "@/app/api/jwt";
+import { GET, POST } from "@/app/api/routeModule";
 
 export const getAllChatPost = async () => {
   const response = await GET("chatposts");
@@ -8,4 +10,23 @@ export const getAllChatPost = async () => {
 export const getOneChatPost = async (chatPostId: string) => {
   const response = await GET(`chatposts/public/${chatPostId}`);
   return response;
+};
+
+export const postComment = async (
+  commentData: string,
+  authData: IAuthData,
+  chatPostId: string
+) => {
+  const res = await POST(
+    commentAPI,
+    `${chatPostId}`,
+    commentData,
+    GenerateAuthHeader(authData)
+  );
+  return res;
+};
+
+export const getComments = async (chatPostId: string) => {
+  const res = await GET(`comments/all/${chatPostId}`);
+  return res;
 };

--- a/ganoverflow-next/src/app/posts/api/chatposts.ts
+++ b/ganoverflow-next/src/app/posts/api/chatposts.ts
@@ -13,7 +13,7 @@ export const getOneChatPost = async (chatPostId: string) => {
 };
 
 export const postComment = async (
-  commentData: string,
+  commentData: { content: string },
   authData: IAuthData,
   chatPostId: string
 ) => {

--- a/ganoverflow-next/src/app/posts/api/chatposts.ts
+++ b/ganoverflow-next/src/app/posts/api/chatposts.ts
@@ -4,3 +4,8 @@ export const getAllChatPost = async () => {
   const response = await GET("chatposts");
   return response;
 };
+
+export const getOneChatPost = async (chatPostId: string) => {
+  const response = await GET(`chatposts/public/${chatPostId}`);
+  return response;
+};

--- a/ganoverflow-next/src/app/posts/api/chatposts.ts
+++ b/ganoverflow-next/src/app/posts/api/chatposts.ts
@@ -1,0 +1,6 @@
+import { GET } from "@/app/api/routeModule";
+
+export const getAllChatPost = async () => {
+  const response = await GET("chatposts");
+  return response;
+};

--- a/ganoverflow-next/src/app/posts/page.tsx
+++ b/ganoverflow-next/src/app/posts/page.tsx
@@ -14,13 +14,15 @@ export default async function PostPage({
       <div className="grid">
         <table className="w-3/5 place-self-center">
           <thead className="posts-tablehead border border-gray-300 border-x-0">
-            <th className="p-2.5">번호</th>
-            <th className="p-2.5">카테고리</th>
-            <th className="p-2.5">제목</th>
-            <th className="p-2.5">글쓴이</th>
-            <th className="p-2.5">작성일</th>
-            <th className="p-2.5">댓글</th>
-            <th className="p-2.5">추천</th>
+            <tr>
+              <th className="p-2.5">번호</th>
+              <th className="p-2.5">카테고리</th>
+              <th className="p-2.5">제목</th>
+              <th className="p-2.5">글쓴이</th>
+              <th className="p-2.5">작성일</th>
+              <th className="p-2.5">댓글</th>
+              <th className="p-2.5">추천</th>
+            </tr>
           </thead>
           <tbody>
             {allPosts.length > 0 ? (

--- a/ganoverflow-next/src/app/posts/page.tsx
+++ b/ganoverflow-next/src/app/posts/page.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { getAllChatPost } from "./api/chatposts";
+
+export default async function PostPage({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const allPosts = await getAllChatPost();
+  console.log("ap", allPosts[0]["userId"]);
+  return (
+    <>
+      <div className="post-title text-xl ">GanOverflow - POSTS</div>
+      <div className="grid">
+        <table className="w-3/5 place-self-center">
+          <thead className="posts-tablehead border border-gray-300 border-x-0">
+            <th className="p-2.5">번호</th>
+            <th className="p-2.5">카테고리</th>
+            <th className="p-2.5">제목</th>
+            <th className="p-2.5">글쓴이</th>
+            <th className="p-2.5">작성일</th>
+            <th className="p-2.5">댓글</th>
+            <th className="p-2.5">추천</th>
+          </thead>
+          <tbody>
+            {allPosts.length > 0 ? (
+              allPosts.map((post: any, id: number) => (
+                <tr
+                  className="border border-x-0 border-spacing-2 border-zinc-500 hover:bg-slate-800"
+                  key={id}
+                >
+                  <td className="py-1">{post?.chatPostId}</td>
+                  <td className="py-1">{post?.category ?? "카테고리"}</td>
+                  <td className="py-1">
+                    <Link href={`/posts/${post?.chatPostId}`}>
+                      {post?.title}
+                    </Link>
+                  </td>
+                  <td className="py-1">
+                    {post?.userId.nickname ?? "작성자 없음"}
+                  </td>
+                  <td className="py-1">
+                    {post?.createdAt.slice(0, 10) ?? "2"}
+                  </td>
+                  <td className="py-1">{post?.comments?.length ?? "2"}</td>
+                  <td className="py-1">{post?.likes ?? "4"}</td>
+                </tr>
+              ))
+            ) : (
+              <></>
+            )}
+          </tbody>
+        </table>
+        {children}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
# 게시판 기능 설명 - frontEnd

1. 상단 navigation바에 게시판 추가 - 라우트는 "/posts"입니다.
2. posts 목록은 SSR, 게시물 detail page는 use client 사용했습니다.
    - 게시물 목록은 깔끔한 css 정리 위해서 table 태그 썼어요. [제목] (post.title)에만 detail page로 가는 링크 걸어놨습니다.
    - 작성자 이름 누르면 작성자 페이지로 연결시킬 생각이에요 (TODO)
    - 게시물 조회수 property도 추가하면 좋을 듯 합니다 (TODO)
    - 페이지네이션 구현 안됐습니다 - Nest에서 기능 찾아보고 작업해볼게요. (TODO)
    - 기본적인 기능 탬플릿은 dcinside 참조했습니다.
3. detail page는 게시물이랑 CommentBox 컴포넌트 분리해놨습니다. 
    - use client 컴포넌트에서는 export [async] function CommentBox() {} 여기에 async 붙이면 안된대요.. 이거 잡느라 시간 많이 썼는데 ㅋㅋㅋㅋ ;; 완전히 리액트18 개념으로 생각하면 될듯합니다.