### PR TITLE
Feat likes - 따봉 기능 구현 완

### DIFF
--- a/ganoverflow-next/src/app/api/axiosInstanceManager.ts
+++ b/ganoverflow-next/src/app/api/axiosInstanceManager.ts
@@ -19,3 +19,4 @@ export const chatPostAPI = GenerateAPI("chatposts");
 export const authAPI = GenerateAPI("auth");
 export const userAPI = GenerateAPI("user");
 export const commentAPI = GenerateAPI("comments");
+export const starAPI = GenerateAPI("stars");

--- a/ganoverflow-next/src/app/api/routeModule.ts
+++ b/ganoverflow-next/src/app/api/routeModule.ts
@@ -35,7 +35,8 @@ export async function AuthPOST(
       console.log(res);
       return `${res.status}: 오류좀보소`;
     }
-    console.log(res);
+    console.log("🚀 ~ file: routeModule.ts:34 ~ res:", res);
+
     return `${res}`;
   } catch (error: any) {
     if (error.response && error.response.data === "Expired token") {

--- a/ganoverflow-next/src/app/posts/[chatPostId]/likes.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/likes.tsx
@@ -3,6 +3,7 @@
 import { getLocalStorageItem } from "@/app/utils/common/localStorage";
 import { postStar } from "../api/chatposts";
 import { useAuthDataHook } from "@/app/utils/jwtHooks/getNewAccessToken";
+import { useRouter } from "next/navigation";
 
 export const LikeBox = ({
   stars,
@@ -14,8 +15,10 @@ export const LikeBox = ({
   const userData = getLocalStorageItem("userData");
   const authData = useAuthDataHook();
 
+  const router = useRouter();
+
   const handleLike = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    let value;
+    let value = 0;
 
     const filteredStar = stars.filter((star) => star.user.id === userData?.id);
     console.log(
@@ -24,37 +27,56 @@ export const LikeBox = ({
     );
 
     if (filteredStar.length === 0) {
+      // ! 한번도 안눌렀을때
       if (e.currentTarget.name === "up") {
         value = 1;
         console.log(value, "따봉");
-        await postStar({
-          chatPostId: chatPostId,
-          authData: await authData,
-          value: value,
-        });
-        return;
       }
       if (e.currentTarget.name === "down") {
         value = -1;
-        console.log(value, "붐따");
-        await postStar({
-          chatPostId: chatPostId,
-          authData: await authData,
-          value: value,
-        });
-        return;
       }
-    }
 
-    if (filteredStar[0].value !== 0) {
-      console.log("따봉/붐따 취소 : 0으로 업데이트");
-      value = 0;
-      await postStar({
+      const res = await postStar({
         chatPostId: chatPostId,
         authData: await authData,
         value: value,
       });
-      return;
+      console.log("🚀 ~ file: likes.tsx:43 ~ handleLike ~ res:", res);
+      if (res.status === 201 || res.status === 204) {
+        router.refresh();
+      }
+    } else {
+      // ! 두번째 누를때!
+      if (filteredStar[0].value !== 0) {
+        console.log("따봉/붐따 취소 : 0으로 업데이트");
+        value = 0;
+        await postStar({
+          chatPostId: chatPostId,
+          authData: await authData,
+          value: value,
+        });
+        return;
+      } else {
+        // ! 두번째 + value 0
+        console.log("value가 0일때 -> 다시 따봉/붐따");
+        if (e.currentTarget.name === "up") {
+          value = 1;
+          console.log(value, "따봉");
+        }
+        if (e.currentTarget.name === "down") {
+          value = -1;
+        }
+
+        const res = await postStar({
+          chatPostId: chatPostId,
+          authData: await authData,
+          value: value,
+        });
+        console.log("🚀 ~ file: likes.tsx:43 ~ handleLike ~ res:", res);
+        if (res.status === 201 || res.status === 204) {
+          router.refresh();
+        }
+      }
     }
   };
   return (
@@ -68,6 +90,10 @@ export const LikeBox = ({
           >
             따봉
           </button>
+          <div>
+            <span>따봉수</span>
+            <span>{stars.length}</span>
+          </div>
           <button
             name="down"
             className="border rounded-lg p-2 mx-8 h-12 hover:bg-slate-500"

--- a/ganoverflow-next/src/app/posts/[chatPostId]/likes.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/likes.tsx
@@ -34,29 +34,36 @@ export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
   //   const userDidLiked = stars.length === 0 ? 0 : stars[0].value;
 
   const handleLike = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    // TODO 로그인 안돼있으면 에러처리 (alert)
+    if (
+      !(await authData) ||
+      (await authData).accessToken === "토큰 갱신에 실패했습니다."
+    ) {
+      alert("로그인을 해주세요");
+      return;
+    }
+
     let value = 0;
-    console.log("🚀 ~ file: likes.tsx:30 ~ LikeBox ~ userDidLiked:", stars);
+
+    const { name } = e.target as HTMLButtonElement;
 
     // ! 한번도 안눌렀거나 따봉 / 붐따 취소해서 userDidLiked가 0인 경우
     if (stars === 0) {
-      if (e.currentTarget.name === "up") {
+      if (name === "up") {
         value = 1;
-      } else if (e.currentTarget.name === "down") {
+      } else if (name === "down") {
         value = -1;
       }
     } else {
       // ! 따봉 / 붐따를 기존에 누른 경우
       // ^ 같은 버튼 두번 누르면 취소
-      if (
-        (e.currentTarget.name === "up" && stars === 1) ||
-        (e.currentTarget.name === "down" && stars === -1)
-      ) {
+      if ((name === "up" && stars === 1) || (name === "down" && stars === -1)) {
         value = 0;
         // ^ 붐따 후 따봉
-      } else if (e.currentTarget.name === "up") {
+      } else if (name === "up") {
         value = 1;
         // ^ 따봉 후 붐따
-      } else if (e.currentTarget.name === "down") {
+      } else if (name === "down") {
         value = -1;
       }
     }
@@ -68,9 +75,8 @@ export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
       value: value,
     });
     if (res.status === 201) {
-      //   console.log("등록후 ", res);
       setStarCount(res.data.count);
-      setStars(res.data.stars);
+      setStars(value);
     }
   };
 
@@ -81,7 +87,7 @@ export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
           <button
             name="up"
             className="border rounded-lg p-2 mx-8 h-12 hover:bg-slate-500"
-            onClick={handleLike}
+            onClick={(e) => handleLike(e)}
           >
             따봉
           </button>
@@ -94,7 +100,7 @@ export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
           <button
             name="down"
             className="border rounded-lg p-2 mx-8 h-12 hover:bg-slate-500"
-            onClick={handleLike}
+            onClick={(e) => handleLike(e)}
           >
             붐따
           </button>

--- a/ganoverflow-next/src/app/posts/[chatPostId]/likes.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/likes.tsx
@@ -11,10 +11,7 @@ export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
   const authData = useAuthDataHook();
 
   const [starCount, setStarCount] = useState(0);
-  //   const [stars, setStars] = useState<{ user: { id: string }; value: number }[]>(
-  //     []
-  //   );
-  const [stars, setStars] = useState<number>(0);
+  const [userDidLike, setUserDidLike] = useState<number>(0);
 
   // ^ stars fetch (GET) : 처음에 한번
   useEffect(() => {
@@ -24,14 +21,9 @@ export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
         (star: { user: { id: string }; value: number }) =>
           star?.user?.id === userData?.id
       );
-      console.log(filteredStar);
-      //   setStars(filteredStar.length === 0 ? 0 : filteredStar[0].value);
+      setUserDidLike(filteredStar.length === 0 ? 0 : filteredStar[0].value);
     });
   }, []);
-
-  // ^ 내(유저)가 눌렀는지 판단하기 : length가 1이면 누른적 있음 / 0이면 한번도 없음
-  //   const filteredStar = stars?.filter((star) => star?.user?.id === userData?.id);
-  //   const userDidLiked = stars.length === 0 ? 0 : stars[0].value;
 
   const handleLike = async (e: React.MouseEvent<HTMLButtonElement>) => {
     // TODO 로그인 안돼있으면 에러처리 (alert)
@@ -48,7 +40,7 @@ export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
     const { name } = e.target as HTMLButtonElement;
 
     // ! 한번도 안눌렀거나 따봉 / 붐따 취소해서 userDidLiked가 0인 경우
-    if (stars === 0) {
+    if (userDidLike === 0) {
       if (name === "up") {
         value = 1;
       } else if (name === "down") {
@@ -57,7 +49,10 @@ export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
     } else {
       // ! 따봉 / 붐따를 기존에 누른 경우
       // ^ 같은 버튼 두번 누르면 취소
-      if ((name === "up" && stars === 1) || (name === "down" && stars === -1)) {
+      if (
+        (name === "up" && userDidLike === 1) ||
+        (name === "down" && userDidLike === -1)
+      ) {
         value = 0;
         // ^ 붐따 후 따봉
       } else if (name === "up") {
@@ -67,7 +62,6 @@ export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
         value = -1;
       }
     }
-    // }
 
     const res = await postStar({
       chatPostId: chatPostId,
@@ -76,7 +70,7 @@ export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
     });
     if (res.status === 201) {
       setStarCount(res.data.count);
-      setStars(value);
+      setUserDidLike(value);
     }
   };
 
@@ -86,7 +80,9 @@ export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
         <div className="post-likes w-1/2 h-32 flex justify-center items-center border">
           <button
             name="up"
-            className="border rounded-lg p-2 mx-8 h-12 hover:bg-slate-500"
+            className={`border rounded-lg p-2 mx-8 h-12 hover:bg-slate-500 ${
+              userDidLike === 1 ? "text-5xl" : ""
+            }`}
             onClick={(e) => handleLike(e)}
           >
             따봉
@@ -95,11 +91,11 @@ export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
             <span>따봉수</span>
             <span>{starCount}</span>
           </div>
-          <span>내가 눌렀던가? {stars === 0 ? "안누름" : stars}</span>
-          <div></div>
           <button
             name="down"
-            className="border rounded-lg p-2 mx-8 h-12 hover:bg-slate-500"
+            className={`border rounded-lg p-2 mx-8 h-12 hover:bg-slate-500 ${
+              userDidLike === -1 ? "text-5xl" : ""
+            }`}
             onClick={(e) => handleLike(e)}
           >
             붐따

--- a/ganoverflow-next/src/app/posts/[chatPostId]/likes.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/likes.tsx
@@ -1,84 +1,79 @@
 "use client";
 
 import { getLocalStorageItem } from "@/app/utils/common/localStorage";
-import { postStar } from "../api/chatposts";
+import { getStars, postStar } from "../api/chatposts";
 import { useAuthDataHook } from "@/app/utils/jwtHooks/getNewAccessToken";
 import { useRouter } from "next/navigation";
+import { useState, useEffect } from "react";
 
-export const LikeBox = ({
-  stars,
-  chatPostId,
-}: {
-  stars: { starId: number; value: number; user: { id: string } }[];
-  chatPostId: string;
-}) => {
+export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
   const userData = getLocalStorageItem("userData");
   const authData = useAuthDataHook();
 
-  const router = useRouter();
+  const [starCount, setStarCount] = useState(0);
+  //   const [stars, setStars] = useState<{ user: { id: string }; value: number }[]>(
+  //     []
+  //   );
+  const [stars, setStars] = useState<number>(0);
+
+  // ^ stars fetch (GET) : 처음에 한번
+  useEffect(() => {
+    getStars(chatPostId).then((res) => {
+      setStarCount(res.count);
+      const filteredStar = res.stars.filter(
+        (star: { user: { id: string }; value: number }) =>
+          star?.user?.id === userData?.id
+      );
+      console.log(filteredStar);
+      //   setStars(filteredStar.length === 0 ? 0 : filteredStar[0].value);
+    });
+  }, []);
+
+  // ^ 내(유저)가 눌렀는지 판단하기 : length가 1이면 누른적 있음 / 0이면 한번도 없음
+  //   const filteredStar = stars?.filter((star) => star?.user?.id === userData?.id);
+  //   const userDidLiked = stars.length === 0 ? 0 : stars[0].value;
 
   const handleLike = async (e: React.MouseEvent<HTMLButtonElement>) => {
     let value = 0;
+    console.log("🚀 ~ file: likes.tsx:30 ~ LikeBox ~ userDidLiked:", stars);
 
-    const filteredStar = stars.filter((star) => star.user.id === userData?.id);
-    console.log(
-      "🚀 ~ file: likes.tsx:16 ~ handleLike ~ filteredStar:",
-      filteredStar
-    );
-
-    if (filteredStar.length === 0) {
-      // ! 한번도 안눌렀을때
+    // ! 한번도 안눌렀거나 따봉 / 붐따 취소해서 userDidLiked가 0인 경우
+    if (stars === 0) {
       if (e.currentTarget.name === "up") {
         value = 1;
-        console.log(value, "따봉");
-      }
-      if (e.currentTarget.name === "down") {
+      } else if (e.currentTarget.name === "down") {
         value = -1;
       }
-
-      const res = await postStar({
-        chatPostId: chatPostId,
-        authData: await authData,
-        value: value,
-      });
-      console.log("🚀 ~ file: likes.tsx:43 ~ handleLike ~ res:", res);
-      if (res.status === 201 || res.status === 204) {
-        router.refresh();
-      }
     } else {
-      // ! 두번째 누를때!
-      if (filteredStar[0].value !== 0) {
-        console.log("따봉/붐따 취소 : 0으로 업데이트");
+      // ! 따봉 / 붐따를 기존에 누른 경우
+      // ^ 같은 버튼 두번 누르면 취소
+      if (
+        (e.currentTarget.name === "up" && stars === 1) ||
+        (e.currentTarget.name === "down" && stars === -1)
+      ) {
         value = 0;
-        await postStar({
-          chatPostId: chatPostId,
-          authData: await authData,
-          value: value,
-        });
-        return;
-      } else {
-        // ! 두번째 + value 0
-        console.log("value가 0일때 -> 다시 따봉/붐따");
-        if (e.currentTarget.name === "up") {
-          value = 1;
-          console.log(value, "따봉");
-        }
-        if (e.currentTarget.name === "down") {
-          value = -1;
-        }
-
-        const res = await postStar({
-          chatPostId: chatPostId,
-          authData: await authData,
-          value: value,
-        });
-        console.log("🚀 ~ file: likes.tsx:43 ~ handleLike ~ res:", res);
-        if (res.status === 201 || res.status === 204) {
-          router.refresh();
-        }
+        // ^ 붐따 후 따봉
+      } else if (e.currentTarget.name === "up") {
+        value = 1;
+        // ^ 따봉 후 붐따
+      } else if (e.currentTarget.name === "down") {
+        value = -1;
       }
     }
+    // }
+
+    const res = await postStar({
+      chatPostId: chatPostId,
+      authData: await authData,
+      value: value,
+    });
+    if (res.status === 201) {
+      //   console.log("등록후 ", res);
+      setStarCount(res.data.count);
+      setStars(res.data.stars);
+    }
   };
+
   return (
     <>
       <div className="flex justify-center my-6">
@@ -92,8 +87,10 @@ export const LikeBox = ({
           </button>
           <div>
             <span>따봉수</span>
-            <span>{stars.length}</span>
+            <span>{starCount}</span>
           </div>
+          <span>내가 눌렀던가? {stars === 0 ? "안누름" : stars}</span>
+          <div></div>
           <button
             name="down"
             className="border rounded-lg p-2 mx-8 h-12 hover:bg-slate-500"

--- a/ganoverflow-next/src/app/posts/[chatPostId]/likes.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/likes.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { getLocalStorageItem } from "@/app/utils/common/localStorage";
+import { postStar } from "../api/chatposts";
+import { useAuthDataHook } from "@/app/utils/jwtHooks/getNewAccessToken";
+
+export const LikeBox = ({
+  stars,
+  chatPostId,
+}: {
+  stars: { starId: number; value: number; user: { id: string } }[];
+  chatPostId: string;
+}) => {
+  const userData = getLocalStorageItem("userData");
+  const authData = useAuthDataHook();
+
+  const handleLike = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    let value;
+
+    const filteredStar = stars.filter((star) => star.user.id === userData?.id);
+    console.log(
+      "🚀 ~ file: likes.tsx:16 ~ handleLike ~ filteredStar:",
+      filteredStar
+    );
+
+    if (filteredStar.length === 0) {
+      if (e.currentTarget.name === "up") {
+        value = 1;
+        console.log(value, "따봉");
+        await postStar({
+          chatPostId: chatPostId,
+          authData: await authData,
+          value: value,
+        });
+        return;
+      }
+      if (e.currentTarget.name === "down") {
+        value = -1;
+        console.log(value, "붐따");
+        await postStar({
+          chatPostId: chatPostId,
+          authData: await authData,
+          value: value,
+        });
+        return;
+      }
+    }
+
+    if (filteredStar[0].value !== 0) {
+      console.log("따봉/붐따 취소 : 0으로 업데이트");
+      value = 0;
+      await postStar({
+        chatPostId: chatPostId,
+        authData: await authData,
+        value: value,
+      });
+      return;
+    }
+  };
+  return (
+    <>
+      <div className="flex justify-center my-6">
+        <div className="post-likes w-1/2 h-32 flex justify-center items-center border">
+          <button
+            name="up"
+            className="border rounded-lg p-2 mx-8 h-12 hover:bg-slate-500"
+            onClick={handleLike}
+          >
+            따봉
+          </button>
+          <button
+            name="down"
+            className="border rounded-lg p-2 mx-8 h-12 hover:bg-slate-500"
+            onClick={handleLike}
+          >
+            붐따
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
@@ -1,5 +1,6 @@
 import { getOneChatPost } from "../api/chatposts";
 import { CommentBox } from "./comments";
+import { LikeBox } from "./likes";
 
 export default async function PostDetailPage({
   params,
@@ -23,15 +24,15 @@ export default async function PostDetailPage({
               <div className="post-user px-3 border border-0 border-r-2">
                 {postData?.userId?.nickname}
               </div>
-              <div className="post-date px-3">{`${postData?.createdAt.slice(
+              <div className="post-date px-3">{`${postData?.createdAt?.slice(
                 0,
                 10
-              )} ${postData?.createdAt.slice(11, 19)}`}</div>
+              )} ${postData?.createdAt?.slice(11, 19)}`}</div>
             </div>
             <div className="post-stats w-1/3 space-x-2">
               <span>따봉 {postData?.likes}</span>
               <span>조회수 {postData?.viewCount}</span>
-              <span>댓글 {postData?.comments.length}</span>
+              <span>댓글 {postData?.comments?.length}</span>
             </div>
           </div>
         </div>
@@ -55,16 +56,7 @@ export default async function PostDetailPage({
               );
             })}
         </div>
-        <div className="flex justify-center my-6">
-          <div className="post-likes w-1/2 h-32 flex justify-center items-center border">
-            <button className="border rounded-lg p-2 mx-8 h-12 hover:bg-slate-500">
-              따봉
-            </button>
-            <button className="border rounded-lg p-2 mx-8 h-12 hover:bg-slate-500">
-              붐따
-            </button>
-          </div>
-        </div>
+        <LikeBox stars={postData?.stars} chatPostId={chatPostId} />
         <CommentBox chatPostId={chatPostId} comments={postData?.comments} />
       </article>
     </div>

--- a/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
@@ -56,7 +56,7 @@ export default async function PostDetailPage({
               );
             })}
         </div>
-        <LikeBox stars={postData?.stars} chatPostId={chatPostId} />
+        <LikeBox chatPostId={chatPostId} />
         <CommentBox chatPostId={chatPostId} comments={postData?.comments} />
       </article>
     </div>

--- a/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
@@ -10,7 +10,7 @@ export default async function PostDetailPage({
   const chatPostId = params.chatPostId;
 
   const postData = await getOneChatPost(chatPostId);
-  console.log(postData);
+  console.log("STARS ", postData.stars);
 
   return (
     <div className="grid">

--- a/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
@@ -30,7 +30,6 @@ export default async function PostDetailPage({
               )} ${postData?.createdAt?.slice(11, 19)}`}</div>
             </div>
             <div className="post-stats w-1/3 space-x-2">
-              <span>따봉 {postData?.likes}</span>
               <span>조회수 {postData?.viewCount}</span>
               <span>댓글 {postData?.comments?.length}</span>
             </div>

--- a/ganoverflow-next/src/app/posts/api/chatposts.ts
+++ b/ganoverflow-next/src/app/posts/api/chatposts.ts
@@ -33,6 +33,11 @@ export const getComments = async (chatPostId: string) => {
   return res;
 };
 
+export const getStars = async (chatPostId: string) => {
+  const res = await GET(`stars/${chatPostId}`);
+  return res;
+};
+
 export const postStar = async ({
   chatPostId,
   value,

--- a/ganoverflow-next/src/app/posts/api/chatposts.ts
+++ b/ganoverflow-next/src/app/posts/api/chatposts.ts
@@ -1,6 +1,6 @@
-import { commentAPI } from "@/app/api/axiosInstanceManager";
+import { commentAPI, starAPI } from "@/app/api/axiosInstanceManager";
 import { GenerateAuthHeader, IAuthData } from "@/app/api/jwt";
-import { GET, POST } from "@/app/api/routeModule";
+import { AuthPOST, GET, POST } from "@/app/api/routeModule";
 
 export const getAllChatPost = async () => {
   const response = await GET("chatposts");
@@ -30,5 +30,26 @@ export const postComment = async (
 
 export const getComments = async (chatPostId: string) => {
   const res = await GET(`comments/all/${chatPostId}`);
+  return res;
+};
+
+export const postStar = async ({
+  chatPostId,
+  value,
+  authData,
+}: {
+  chatPostId: string;
+  value: number;
+  authData: IAuthData;
+}) => {
+  const res = await AuthPOST(
+    starAPI,
+    "",
+    {
+      chatPostId: chatPostId,
+      like: value,
+    },
+    authData
+  );
   return res;
 };

--- a/ganoverflow-next/src/app/posts/api/chatposts.ts
+++ b/ganoverflow-next/src/app/posts/api/chatposts.ts
@@ -42,14 +42,14 @@ export const postStar = async ({
   value: number;
   authData: IAuthData;
 }) => {
-  const res = await AuthPOST(
+  const res = await POST(
     starAPI,
     "",
     {
       chatPostId: chatPostId,
       like: value,
     },
-    authData
+    GenerateAuthHeader(authData)
   );
   return res;
 };


### PR DESCRIPTION
# 1. 따봉 기능 설명
- 유저는 로그인 했을 때만 따봉 / 붐따 누를 수 있음
- 사용자가 따봉 / 붐따 시 자기가 누른 버튼 크기 커지게 해놓음 (임시) => userDidLike STATE로 관리
- 따봉 / 붐따 두번 누르면 취소됨

# 2. 코드
- 첫 렌더시 useEffect 훅으로 stars를 fetch. response에는 {stars : stars[], count : number} 들어있음. (NEST 서버에서 처리해서 보내줌)
- 두가지 state 사용 : starCount, userDidLike. starCount에 response.count 박아넣음.
- userDidLike는 처음에는 fetch 후 response.stars에서 user가 매칭되는거 filter로 남겨서 -1, 0, 1 중 하나 할당함.
- POST 요청을 보낼때마다 response로 {stars : stars[], count : number}를 다시 보내주도록 NEST에서 service를 짜놨음. 그래서 POST 이후에 response를 보고 위에서 한 과정 (state 초기값 설정하는것과 같이) 함.