### PR TITLE
`feat-posts`: PDP 중 `postDetailMain` 컴포넌트화 및 부가작업

### DIFF
--- a/ganoverflow-next/src/app/posts/[chatPostId]/components/comments.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/components/comments.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { ChangeEvent, useEffect, useState } from "react";
-import { getComments, postComment } from "../api/chatposts";
+import { getComments, postComment } from "../../api/chatposts";
 import { useAuthDataHook } from "@/utils/jwtHooks/getNewAccessToken";
 import { useRouter } from "next/navigation";
 import { parseDate, parseDateWithSeconds } from "@/utils/parseDate";

--- a/ganoverflow-next/src/app/posts/[chatPostId]/components/likes.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/components/likes.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { getSessionStorageItem } from "@/utils/common/sessionStorage";
-import { getStars, postStar } from "../api/chatposts";
+import { getStars, postStar } from "@/app/posts/api/chatposts";
 import { useAuthDataHook } from "@/utils/jwtHooks/getNewAccessToken";
 import { useState, useEffect } from "react";
-
 
 export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {
   const userData = getSessionStorageItem("userData");

--- a/ganoverflow-next/src/app/posts/[chatPostId]/components/postDetailMain.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/components/postDetailMain.tsx
@@ -1,0 +1,72 @@
+import {
+  IPostHeaderProps,
+} from "@/interfaces/IProps/posts";
+import { parseDate } from "@/utils/parseDate";
+
+export const PostDetailMain = ({ postData }: any) => {
+  // TODO: any를 IChatPost 수정해서 넣어주기!
+  return (
+    <div className="grid">
+      <article className="post-detail-main w-3/5 place-self-center">
+        <PostHeader
+          chatpostName={postData?.chatpostName}
+          nickname={postData?.userId?.nickname}
+          createdAt={postData?.createdAt}
+          viewCount={postData?.viewCount}
+          commentCount={postData?.comments?.length}
+        />
+        <PostChatPair pairs={postData?.chatPair} />
+      </article>
+    </div>
+  );
+};
+
+const PostHeader: React.FC<IPostHeaderProps> = ({
+  chatpostName,
+  nickname,
+  createdAt,
+  viewCount,
+  commentCount,
+}) => {
+  return (
+    <div className="post-chatpostName-box w-full border border-x-0 border-green-500 border-t-4 py-5 flex flex-col">
+      <h2 className="post-chatpostName text-start px-3 text-3xl text">
+        {chatpostName}
+      </h2>
+      <div className="post-userdate-box flex flex-row justify-between">
+        <div className="w-full flex flex-row">
+          <div className="post-user px-3 border border-0 border-r-2">
+            {nickname}
+          </div>
+          <div className="post-date px-3">{parseDate(createdAt)}</div>
+        </div>
+        <div className="post-stats w-1/3 space-x-2">
+          <span>조회수 {viewCount}</span>
+          <span>댓글 {commentCount}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const PostChatPair = ({ pairs }: any) => {
+  // Todo: any 바꿔주기!
+  return (
+    <div className="post-chat-box min-h-[500px]">
+      {pairs
+        .sort(({ pairOne, pairTwo }: any) => pairOne.order - pairTwo.order)
+        .map((pair: any, idx: number) => (
+          <div key={idx}>
+            <div>
+              <div>Q</div>
+              <div>{pair.question}</div>
+            </div>
+            <div>
+              <div>A</div>
+              <div>{pair.answer}</div>
+            </div>
+          </div>
+        ))}
+    </div>
+  );
+};

--- a/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/page.tsx
@@ -1,7 +1,8 @@
 import { parseDate } from "@/utils/parseDate";
 import { getOneChatPost } from "../api/chatposts";
-import { CommentBox } from "./comments";
-import { LikeBox } from "./likes";
+import { CommentBox } from "./components/comments";
+import { LikeBox } from "./components/likes";
+import { PostDetailMain } from "./components/postDetailMain";
 
 export default async function PostDetailPage({
   params,
@@ -10,51 +11,13 @@ export default async function PostDetailPage({
 }) {
   const chatPostId = params.chatPostId;
 
-  const postData = await getOneChatPost(chatPostId);
+  const postData = await getOneChatPost(chatPostId); // todo: 해당 함수 반환값 인터페이스 정의
   console.log("STARS ", postData.stars);
 
   return (
     <div className="grid">
       <article className="post-detail-main w-3/5 place-self-center">
-        <div className="post-chatpostName-box w-full border border-x-0 border-green-500 border-t-4 py-5 flex flex-col">
-          <h2 className="post-chatpostName text-start px-3 text-3xl text">
-            {postData?.chatpostName}
-          </h2>
-          <div className="post-userdate-box flex flex-row justify-between">
-            <div className="w-full flex flex-row">
-              <div className="post-user px-3 border border-0 border-r-2">
-                {postData?.userId?.nickname}
-              </div>
-              <div className="post-date px-3">
-                {parseDate(postData?.createdAt)}
-              </div>
-            </div>
-            <div className="post-stats w-1/3 space-x-2">
-              <span>조회수 {postData?.viewCount}</span>
-              <span>댓글 {postData?.comments?.length}</span>
-            </div>
-          </div>
-        </div>
-        <div className="post-chat-box min-h-[500px]">
-          {postData?.chatPair
-            ?.sort(
-              (pairOne: any, pairTwo: any) => pairOne.order - pairTwo.order
-            )
-            .map((pair: any, idx: number) => {
-              return (
-                <div key={idx}>
-                  <div>
-                    <div>Q</div>
-                    <div>{pair?.question}</div>
-                  </div>
-                  <div>
-                    <div>A</div>
-                    <div>{pair?.answer}</div>
-                  </div>
-                </div>
-              );
-            })}
-        </div>
+        <PostDetailMain postData={postData} />
         <LikeBox chatPostId={chatPostId} />
         <CommentBox chatPostId={chatPostId} comments={postData?.comments} />
       </article>

--- a/ganoverflow-next/src/interfaces/IProps/posts.ts
+++ b/ganoverflow-next/src/interfaces/IProps/posts.ts
@@ -1,0 +1,14 @@
+import { IChatPair } from "../chat";
+import { IChatPost } from "../chatpost";
+
+export interface IPostHeaderProps {
+  chatpostName?: IChatPost["chatpostName"];
+  nickname: string;
+  createdAt: string;
+  viewCount: number;
+  commentCount: number;
+}
+
+export interface IPostChatPairProps {
+  // 작성 및 활용 필요
+}

--- a/ganoverflow-next/src/interfaces/chatpost.d.ts
+++ b/ganoverflow-next/src/interfaces/chatpost.d.ts
@@ -6,16 +6,26 @@ interface IComment {
   userId: string;
   userLikes: User[];
   content: string;
-  createdAt: Date;
+  createdAt: string;
   delYn: string;
 }
+
 
 interface IChatPost {
   chatPostId: string;
   chatpostName: string;
   userId: string;
   categoryName?: string | null;
-  createdAt: Date;
+  createdAt: string;
   delYn: "Y" | "N";
   chatPair?: IChatPair[] | null;
+  viewCount: number;
+  comments: IComment[];
+  // stars: Star[]; 
 }
+
+// Star 엔티티를 정확히 모르겠어서 비워두겠습니다! 이거 완성되면 posts쪽에 하나씩 연결하면 좋을것 같아요
+// interface IStar {
+//   starId: string;
+//   userid: string;
+// }


### PR DESCRIPTION
### 1. [chatPostId]폴더 내 components 폴더 생성 및 컴포넌트 일괄 이동 

<br>

### 2. postDetailMain.tsx: 
PostHeader, PostChatPair로 분리 및 조합한 컴포넌트 서술부에 import -> 가독성 제고

<br>

### 3. interfaces/chatpost.d.ts : 
nest에서 업데이트된 IChatpost 반영 노력(미완) IStar 완성 필요! - 완성 이후, posts 관련 함수 및 컴포넌트에 명시해주기

<br>

### 4. interfaces/posts.d.ts : 
posts관련 IProps 정의 (추가 정의 필요)

<br>

---

<br>
@hongregii : 해당 PR은 main으로의 반영을 위해 임의로 머지해두겠습니다!