### PR TITLE
`feat-chat` : SideBar에서 선택한 `chat 로드`   &   fix: jwt hook 폴더 hooks로 이동 

### DIFF
--- a/ganoverflow-next/src/app/chat/api/chat.ts
+++ b/ganoverflow-next/src/app/chat/api/chat.ts
@@ -33,6 +33,17 @@ export const getAllChatPostsByUserId = async (
   return response;
 };
 
+export const getOneChatPostById = async (
+  chatpostId: string,
+  authData: IAuthData
+) => {
+  const response = await GET("chatposts", {
+    params: chatpostId,
+    headers: GenerateAuthHeader(authData),
+  });
+  return response;
+};
+
 export const getFoldersByUser = async (userId: string, authData: IAuthData) => {
   console.log("getFoldersByUser authData:", authData);
 

--- a/ganoverflow-next/src/app/chat/components/Dnd/Container.tsx
+++ b/ganoverflow-next/src/app/chat/components/Dnd/Container.tsx
@@ -10,58 +10,65 @@ import { accessTokenState } from "@/atoms/jwt";
 import { getSessionStorageItem } from "@/utils/common/sessionStorage";
 import useDidMountEffect from "@/hooks/useDidMountEffect";
 import { putFoldersByUser } from "../../api/chat";
-import { IFolderWithPostsDTO } from "@/interfaces/chat";
+import { IFolderWithPostsDTO, TLoadThisChatHandler } from "@/interfaces/chat";
 
-export const Container = memo(() => {
-  const [foldersData, setFoldersData] = useRecoilState<IFolderWithPostsDTO[]>(
-    foldersWithChatpostsState
-  );
-  const [isFolderUpdated, setIsFolderUpdated] =
-    useRecoilState<boolean>(isFolderUpdatedState);
+export const Container = memo(
+  ({ loadThisChatHandler }: { loadThisChatHandler: TLoadThisChatHandler }) => {
+    const [foldersData, setFoldersData] = useRecoilState<IFolderWithPostsDTO[]>(
+      foldersWithChatpostsState
+    );
+    const [isFolderUpdated, setIsFolderUpdated] =
+      useRecoilState<boolean>(isFolderUpdatedState);
 
-  const accessToken = useRecoilValue(accessTokenState);
-  const userData = getSessionStorageItem("userData");
+    const accessToken = useRecoilValue(accessTokenState);
+    const userData = getSessionStorageItem("userData");
 
-  // 첫 마운트 무시 커스텀 훅
-  useDidMountEffect(() => {
-    const updateFolders = async () => {
-      // folder 변경사항(폴더 추가, 제거, 포스트 소속 이동) 서버로 PUT
-      const updatedFoldersWithPosts = await putFoldersByUser(
-        userData.id,
-        foldersData,
-        {
-          accessToken,
-          userId: userData.id,
-        }
-      );
+    // 첫 마운트 무시 커스텀 훅
+    useDidMountEffect(() => {
+      const updateFolders = async () => {
+        // folder 변경사항(폴더 추가, 제거, 포스트 소속 이동) 서버로 PUT
+        const updatedFoldersWithPosts = await putFoldersByUser(
+          userData.id,
+          foldersData,
+          {
+            accessToken,
+            userId: userData.id,
+          }
+        );
 
-      setFoldersData(updatedFoldersWithPosts); // 데이터 정합성을 위한 folder state update
-    };
+        setFoldersData(updatedFoldersWithPosts); // 데이터 정합성을 위한 folder state update
+      };
 
-    if (isFolderUpdated) {
-      setIsFolderUpdated(false);
-      return;
-    }
+      if (isFolderUpdated) {
+        setIsFolderUpdated(false);
+        return;
+      }
 
-    console.log("useDidMount!!!!");
-    updateFolders();
-    setIsFolderUpdated(true);
-  }, [foldersData]);
+      console.log("useDidMount!!!!");
+      updateFolders();
+      setIsFolderUpdated(true);
+    }, [foldersData]);
 
-  return (
-    <div>
-      <div
-        style={{
-          overflow: "hidden",
-          clear: "both",
-          display: "flex",
-          flexDirection: "column",
-        }}
-      >
-        {foldersData.map((folder: IFolderWithPostsDTO, idx: number) => (
-          <Folder curFolder={folder} key={folder.folderId} idx={idx} />
-        ))}
+    return (
+      <div>
+        <div
+          style={{
+            overflow: "hidden",
+            clear: "both",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          {foldersData.map((folder: IFolderWithPostsDTO, idx: number) => (
+            <Folder
+              curFolder={folder}
+              key={folder.folderId}
+              idx={idx}
+              loadThisChatHandler={loadThisChatHandler}
+            />
+          ))}
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);

--- a/ganoverflow-next/src/app/chat/components/Dnd/Folder.tsx
+++ b/ganoverflow-next/src/app/chat/components/Dnd/Folder.tsx
@@ -2,7 +2,7 @@ import { useDrop } from "react-dnd";
 import { Chatpost } from "./Chatpost";
 import React, { useState } from "react";
 import FolderIcon from "@mui/icons-material/Folder";
-import { IFolderWithPostsDTO } from "@/interfaces/chat";
+import { IFolderWithPostsDTO, TLoadThisChatHandler } from "@/interfaces/chat";
 import { useRecoilState } from "recoil";
 import { foldersWithChatpostsState, isFolderSpreadState } from "@/atoms/folder";
 
@@ -23,9 +23,11 @@ const style: React.CSSProperties = {
 export const Folder = ({
   curFolder,
   idx,
+  loadThisChatHandler,
 }: {
   curFolder: IFolderWithPostsDTO;
   idx: number;
+  loadThisChatHandler: TLoadThisChatHandler;
 }) => {
   const [{ canDrop, isOver }, drop] = useDrop(() => ({
     accept: "chatpost",
@@ -63,6 +65,7 @@ export const Folder = ({
               curFolderId={curFolder.folderId}
               key={chatpost.chatPostId}
               isDefault={true}
+              loadThisChatHandler={loadThisChatHandler}
             />
           ))}
         </div>
@@ -76,6 +79,7 @@ export const Folder = ({
                 curFolderId={curFolder.folderId}
                 key={chatpost.chatPostId}
                 isDefault={false}
+                loadThisChatHandler={loadThisChatHandler}
               />
             ))}
         </>

--- a/ganoverflow-next/src/app/chat/components/Dnd/index.tsx
+++ b/ganoverflow-next/src/app/chat/components/Dnd/index.tsx
@@ -2,12 +2,17 @@ import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { Container } from "./Container";
 import React from "react";
+import { TLoadThisChatHandler } from "@/interfaces/chat";
 
-export function FolderFileNoOrderDND() {
+export function FolderFileNoOrderDND({
+  loadThisChatHandler,
+}: {
+  loadThisChatHandler: TLoadThisChatHandler;
+}) {
   return (
     <div className="FolderFileNoOrderDND">
       <DndProvider backend={HTML5Backend}>
-        <Container />
+        <Container loadThisChatHandler={loadThisChatHandler} />
       </DndProvider>
     </div>
   );

--- a/ganoverflow-next/src/app/chat/components/chatMain.tsx
+++ b/ganoverflow-next/src/app/chat/components/chatMain.tsx
@@ -4,6 +4,8 @@ import CircularCheckbox from "@/components/common/CheckBox/CircularCheckBox";
 import { IChatMainProps } from "@/interfaces/IProps/chat";
 import { getAllCategories } from "../api/chat";
 import { SaveChatModal } from "./SaveChatModal";
+import { useRecoilState } from "recoil";
+import { isLoadedChatState } from "@/atoms/chat";
 
 interface ICategories {
   categoryName: string;
@@ -24,8 +26,8 @@ export const ChatMain = ({
   scrollRef,
 }: IChatMainProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-
   const [categories, setCategories] = useState<ICategories[]>([]);
+  const [isLoadedChat, setIsLoadedChat] = useRecoilState(isLoadedChatState);
 
   return (
     <div className="flex flex-col h-full">
@@ -40,6 +42,19 @@ export const ChatMain = ({
         <></>
       )}
       <div className="fixed right-36 bottom-24 z-10 hidden lg:block">
+        {isLoadedChat && (
+          <div className="mb-4">
+            <button
+              className="w-36 h-12 bg-sky-700 text-white rounded-lg"
+              onClick={() => {
+                setIsLoadedChat(false);
+                // setChatSavedStatus("F");
+              }}
+            >
+              채팅 이어하기
+            </button>
+          </div>
+        )}
         {chatSavedStatus === "T" ? (
           <>
             <button
@@ -71,25 +86,26 @@ export const ChatMain = ({
             >
               <div className="chatPairContainer h-full flex flex-col sm:flex-row items-center w-3/5 md:w-2/5 m-auto">
                 <div className="chatPairBox w-full flex flex-col justify-center self-center">
-                  <div
-                    key={index}
-                    className={`msgBox p-4 max-w-sm text-xs ${
-                      chatLine.isUser
-                        ? "bg-blue-500 text-white self-end rounded-chat-question" //사용자 질문
-                        : "bg-gray-500 self-start rounded-chat-answer" //GPT 답변
-                    } inline-block`}
-                  >
-                    {chatLine.question}
-                  </div>
-                  <div className="msgBox p-4 max-w-sm text-xs bg-gray-500 self-start rounded-chat-answer mt-4 text-white">
-                    {chatLine.answer}
-                  </div>
+                  {chatLine.question && (
+                    <div
+                      key={index}
+                      className={`msgBox p-4 max-w-sm text-xs ${"bg-blue-500 text-white self-end rounded-chat-question"} inline-block`}
+                    >
+                      {chatLine.question}
+                    </div>
+                  )}
+
+                  {chatLine.answer && (
+                    <div className="msgBox p-4 max-w-sm text-xs bg-gray-500 self-start rounded-chat-answer mt-4 text-white">
+                      {chatLine.answer}
+                    </div>
+                  )}
                 </div>
                 <div className="checkboxContainer ml-12 w-full sm:w-3 sm:h-full">
                   <div className="flex flex-row justify-end w-full h-full">
                     <CircularCheckbox
                       isDisabled={chatSavedStatus}
-                      isChecked={chatLine.isChecked}
+                      isChecked={!!chatLine.isChecked}
                       onChangeCheckBox={() => onChangeCheckBox(index)}
                     />
                   </div>

--- a/ganoverflow-next/src/app/chat/components/chatSideBar.tsx
+++ b/ganoverflow-next/src/app/chat/components/chatSideBar.tsx
@@ -9,6 +9,7 @@ import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
 
 export default function ChatSideBar({
   onClickNewChatBtn,
+  loadThisChatHandler,
 }: // foldersData,
 IChatSideBarProps) {
   const [foldersData, setFoldersData] = useRecoilState<IFolderWithPostsDTO[]>(
@@ -16,7 +17,7 @@ IChatSideBarProps) {
   );
 
   const onClickNewFolderBtn = () => {
-    // Default folder(= ID 0), NewFolder, OtherFolders 순으로 정렬, 저장  
+    // Default folder(= ID 0), NewFolder, OtherFolders 순으로 정렬, 저장
     const newFolderId =
       foldersData.reduce(
         (acc, cur) => (cur.folderId > acc ? cur.folderId : acc),
@@ -61,7 +62,7 @@ IChatSideBarProps) {
           </div>
           <div className="plain-text text-black py-2">my posts</div>
           <div className="list-container overflow-y-auto h-screen pb-[200px]">
-            <FolderFileNoOrderDND />
+            <FolderFileNoOrderDND loadThisChatHandler={loadThisChatHandler} />
           </div>
         </div>
       </div>

--- a/ganoverflow-next/src/app/chat/page.tsx
+++ b/ganoverflow-next/src/app/chat/page.tsx
@@ -6,6 +6,7 @@ import {
   IChat,
   IChatPair,
   IFolderWithPostsDTO,
+  TLoadThisChatHandler,
 } from "@/interfaces/chat";
 import { useAuthDataHook } from "@/utils/jwtHooks/getNewAccessToken";
 import { getFoldersByUser, sendChatPost } from "./api/chat";
@@ -20,6 +21,7 @@ import {
   ITitleAndCategory,
 } from "@/interfaces/IProps/chat";
 import { foldersWithChatpostsState } from "@/atoms/folder";
+import { isLoadedChatState } from "@/atoms/chat";
 
 export default function ChatPage() {
   useAuthDataHook();
@@ -40,6 +42,7 @@ export default function ChatPage() {
     foldersWithChatpostsState
   );
   const [currStream, setCurrStream] = useState<string>("");
+  const [isLoadedChat, setIsLoadedChat] = useRecoilState(isLoadedChatState);
 
   // foldersData - case 1)
   useEffect(() => {
@@ -100,7 +103,6 @@ export default function ChatPage() {
       {
         question: questionInput,
         answer: "",
-        isUser: true,
         isChecked: false,
       },
     ]);
@@ -164,6 +166,16 @@ export default function ChatPage() {
     setQuestionInput("");
   };
 
+  const loadThisChatHandler: TLoadThisChatHandler = async (
+    chatPairs: IChatPair[]
+  ) => {
+    setChatPairs(chatPairs as IChatPair[]);
+    //// todo: load한 chatPairs들에 대해, checkbox checked 설정
+    // setCheckCnt(0);
+    setChatSavedStatus("T");
+    setQuestionInput("");
+  };
+
   return (
     <>
       <ChatMain
@@ -183,7 +195,7 @@ export default function ChatPage() {
       <ChatSideBar
         onClickNewChatBtn={onClickNewChatBtn}
         chatSavedStatus={chatSavedStatus}
-        // foldersData={foldersData}
+        loadThisChatHandler={loadThisChatHandler}
       />
     </>
   );

--- a/ganoverflow-next/src/app/chat/page.tsx
+++ b/ganoverflow-next/src/app/chat/page.tsx
@@ -8,7 +8,7 @@ import {
   IFolderWithPostsDTO,
   TLoadThisChatHandler,
 } from "@/interfaces/chat";
-import { useAuthDataHook } from "@/utils/jwtHooks/getNewAccessToken";
+import { useAuthDataHook } from "@/hooks/jwtHooks/getNewAccessToken";
 import { getFoldersByUser, sendChatPost } from "./api/chat";
 import { ChatMain } from "./components/chatMain";
 import { accessTokenState } from "@/atoms/jwt";

--- a/ganoverflow-next/src/app/layout.tsx
+++ b/ganoverflow-next/src/app/layout.tsx
@@ -16,7 +16,7 @@ import { RecoilRoot, useRecoilState, useSetRecoilState } from "recoil";
 import { userState } from "@/atoms/user";
 import { accessTokenState } from "@/atoms/jwt";
 import { getSessionStorageItem } from "@/utils/common/sessionStorage";
-import { useAuthDataHook } from "@/utils/jwtHooks/getNewAccessToken";
+import { useAuthDataHook } from "@/hooks/jwtHooks/getNewAccessToken";
 
 const siteTitle = "최고의 머시깽이, GanOverflow";
 const siteDescription = "Gan Overflow는 ...입니당. 최고의 경험을 누려보세요!";

--- a/ganoverflow-next/src/app/posts/[chatPostId]/components/comments.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/components/comments.tsx
@@ -2,7 +2,7 @@
 
 import React, { ChangeEvent, useEffect, useState } from "react";
 import { getComments, postComment } from "../../api/chatposts";
-import { useAuthDataHook } from "@/utils/jwtHooks/getNewAccessToken";
+import { useAuthDataHook } from "@/hooks/jwtHooks/getNewAccessToken";
 import { useRouter } from "next/navigation";
 import { parseDate, parseDateWithSeconds } from "@/utils/parseDate";
 

--- a/ganoverflow-next/src/app/posts/[chatPostId]/components/likes.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/components/likes.tsx
@@ -2,7 +2,7 @@
 
 import { getSessionStorageItem } from "@/utils/common/sessionStorage";
 import { getStars, postStar } from "@/app/posts/api/chatposts";
-import { useAuthDataHook } from "@/utils/jwtHooks/getNewAccessToken";
+import { useAuthDataHook } from "@/hooks/jwtHooks/getNewAccessToken";
 import { useState, useEffect } from "react";
 
 export const LikeBox = ({ chatPostId }: { chatPostId: string }) => {

--- a/ganoverflow-next/src/atoms/chat.ts
+++ b/ganoverflow-next/src/atoms/chat.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const isLoadedChatState = atom({
+  key: "isLoadedChatState",
+  default: false,
+});

--- a/ganoverflow-next/src/hooks/jwtHooks/getNewAccessToken.ts
+++ b/ganoverflow-next/src/hooks/jwtHooks/getNewAccessToken.ts
@@ -5,7 +5,7 @@ import { useEffect } from "react";
 import { IAuthData, fetchAccessToken } from "@/app/api/jwt";
 
 import { accessTokenState } from "@/atoms/jwt";
-import { getSessionStorageItem } from "../common/sessionStorage";
+import { getSessionStorageItem } from "../../utils/common/sessionStorage";
 
 export const getNewAccessTokenHook = async () => {
   const [accessToken, setAccessToken] = useRecoilState(accessTokenState);

--- a/ganoverflow-next/src/interfaces/IProps/chat.ts
+++ b/ganoverflow-next/src/interfaces/IProps/chat.ts
@@ -1,4 +1,4 @@
-import { ChatSavedStatus, IChatPair, IFolderWithPostsDTO } from "../chat";
+import { ChatSavedStatus, IChatPair, IFolderWithPostsDTO, TLoadThisChatHandler } from "../chat";
 
 export interface IChatMainProps {
   onChangeTitleAndCategory: (
@@ -20,6 +20,7 @@ export interface IChatMainProps {
 export interface IChatSideBarProps {
   onClickNewChatBtn: (e: React.MouseEvent) => void;
   chatSavedStatus: ChatSavedStatus;
+  loadThisChatHandler: TLoadThisChatHandler
   // foldersData: IFolderWithPostsDTO[];
   // foldersData: any;
 }

--- a/ganoverflow-next/src/interfaces/chat.d.ts
+++ b/ganoverflow-next/src/interfaces/chat.d.ts
@@ -7,7 +7,6 @@ export interface IChat {
 export interface IChatPair {
   question: string;
   answer: string;
-  isUser: boolean;
   isChecked: boolean;
 }
 
@@ -34,3 +33,5 @@ export interface ISerailzedChatposts {
   folderId: number;
   folderName: string;
 }
+
+export type TLoadThisChatHandler = (chatPairs: IChatPair[]) => void;


### PR DESCRIPTION
사이드바의 저장된 포스트 클릭에 따른 chatpost 가져오기 등에 관한 작업을 수행했습니다.

<br>

### 1. `isLoadedChat` 상태를 통해, 이어서 하기 버튼 조건 렌더링
아직 실제 동작까지는 연결하지 못했습니다 ( 관련된 상태가 너무 많아서 일단 UI만 작업함 )

<br>

### 2. `IChatPair`에 정의된 불필요한 isUser 필드 제거 및 관련 chat 조건렌더 로직 개선

<br>

### 3. `getOneChatPostById`: 포스트ID를 통해 챗포스트 정보만 가져오는 함수

---
@hongregii : dev로 임의 머지하겠습니다!