### PR TITLE
Feat darkmode

### DIFF
--- a/ganoverflow-next/src/app/accounts/login/page.tsx
+++ b/ganoverflow-next/src/app/accounts/login/page.tsx
@@ -48,7 +48,7 @@ const Login = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-100 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen dark:bg-gray-700 bg-gray-100 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <h2 className="text-center text-3xl font-extrabold text-gray-900">
           로그인

--- a/ganoverflow-next/src/app/layout.tsx
+++ b/ganoverflow-next/src/app/layout.tsx
@@ -37,16 +37,24 @@ export default function RootLayout({
   // home: boolean,
   // offFooter: boolean,
 }) {
+  const [isDarkMode, setIsDarkMode] = useState(true);
+  const toggleDarkMode = () => {
+    setIsDarkMode((prev) => !prev);
+  };
   return (
     <html
       lang="en"
-      className={`${inter.className} h-full scroll-smooth antialiased`}
+      className={`${inter.className} ${
+        isDarkMode ? "dark" : ""
+      } h-full scroll-smooth antialiased`}
     >
       <CapsulizedHead />
       <RecoilRoot>
         <body className="flex min-h-full flex-col">
-          <Header />
-          <main className="grow pt-[44px] md:pt-[68px]">{children}</main>
+          <Header toggleDarkMode={toggleDarkMode} isDarkMode={isDarkMode} />
+          <main className="grow pt-[44px] md:pt-[68px] bg-slate-300 dark:bg-slate-800 dark:text-slate-100">
+            {children}
+          </main>
           {/* {!offFooter &&  */}
           {/* <Footer /> */}
           {/* } */}
@@ -77,7 +85,13 @@ const CapsulizedHead = (): JSX.Element => {
   );
 };
 
-const Header = (): JSX.Element => {
+const Header = ({
+  toggleDarkMode,
+  isDarkMode,
+}: {
+  toggleDarkMode: () => void;
+  isDarkMode: boolean;
+}): JSX.Element => {
   const [isOffCanvasOpen, setIsOffCanvasOpen] = useState(false);
   const [user, setUser] = useRecoilState(userState);
 
@@ -137,15 +151,6 @@ const Header = (): JSX.Element => {
                 채팅
               </Link>
               <Link
-                href="/"
-                target="_blank"
-                // rel="noreferrer"
-                className="text-[#AEAEB2] font-inter text-sm px-4 py-5 font-semibold"
-                passHref
-              >
-                머시기
-              </Link>
-              <Link
                 href="/posts"
                 className="text-[#AEAEB2] font-inter text-sm px-4 py-5 font-semibold"
                 passHref
@@ -166,6 +171,9 @@ const Header = (): JSX.Element => {
               >
                 CONTACT
               </Link>
+              <button className="text-zinc-200" onClick={toggleDarkMode}>
+                {isDarkMode === true ? "LIGHT" : "DARK"}
+              </button>
             </div>
           </div>
           <div className="col-sapn-1 self-center">

--- a/ganoverflow-next/src/app/posts/page.tsx
+++ b/ganoverflow-next/src/app/posts/page.tsx
@@ -12,7 +12,7 @@ export default async function PostPage({
 
   const allPosts = await getAllChatPost({ page: currentPage });
 
-  // ! 페이징용 더미데이터
+  // ! 페이징용 게시물수
   const totalCount = allPosts.postCount;
   const totalPage = Math.ceil(totalCount / 10);
 
@@ -21,6 +21,18 @@ export default async function PostPage({
   );
   pagingButtons[0] = "<";
   pagingButtons[pagingButtons.length - 1] = ">";
+
+  // ! 10개 미만이면 10개로 채워줘야 함.
+  while (allPosts.posts.length < 10) {
+    allPosts.posts.push({
+      post: "",
+      id: 0,
+      createdAt: "",
+      stars: [],
+      category: " ",
+      comments: [],
+    });
+  }
 
   return (
     <>
@@ -40,10 +52,10 @@ export default async function PostPage({
             </tr>
           </thead>
           <tbody>
-            {allPosts.posts.length > 0 ? (
+            {allPosts.posts.length === 10 ? (
               allPosts.posts.map((post: any, id: number) => (
                 <tr
-                  className="border border-x-0 border-spacing-2 border-zinc-500 hover:bg-slate-800"
+                  className="border border-x-0 border-spacing-2 border-zinc-500 hover:bg-slate-600"
                   key={id}
                 >
                   <td className="py-1">{post?.chatPostId}</td>
@@ -53,13 +65,11 @@ export default async function PostPage({
                       {post?.chatpostName}
                     </Link>
                   </td>
-                  <td className="py-1">
-                    {post?.userId?.nickname ?? "작성자 없음"}
-                  </td>
+                  <td className="py-1">{post?.userId?.nickname ?? ""}</td>
                   <td className="py-1">
                     {parseDateWithSeconds(post?.createdAt)}
                   </td>
-                  <td className="py-1">{post?.comments?.length ?? 0}</td>
+                  <td className="py-1">{post?.comments?.length}</td>
                   <td className="py-1">{post?.viewCount}</td>
                   <td className="py-1">
                     {post?.stars.reduce(

--- a/ganoverflow-next/src/styles/globals.css
+++ b/ganoverflow-next/src/styles/globals.css
@@ -94,8 +94,8 @@ body,
     "Segoe UI Symbol";
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizelegibility;
-  color: rgb(118, 118, 118);
-  background-color: #1c2128;
+  /* color: rgb(118, 118, 118);
+  background-color: #1c2128; */
 }
 
 /* Common */

--- a/ganoverflow-next/tailwind.config.js
+++ b/ganoverflow-next/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 
 module.exports = {
+  darkMode: "class",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx}",
     "./src/components/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
# TailwindCss X NextJS X Darkmode

NextJs + TailwindCss의 장점 : 다크모드 구현이 편리하다는 것.
기존 코드에서는 globals.css에 백그라운드 색깔과 폰트 색깔을 정해줬습니다.

기본적으로 tailwind className 중 "dark:<클래스명>"을 사용하면, 브라우저 세팅 (보통 OS 세팅을 따라갑니다) 에 따라 다크모드가 활성화돼있을 때 해당 style이 발동됩니다.

그러나 script로 브라우저 세팅을 바꿀 수는 없다고 합니다. 그래서 tailwind는 class 기반 다크모드를 지원합니다.
``` tailwind.config.js
// tailwind.config.js
module.exports = {
  darkMode: 'class',
  // ...
}
```
를 추가하면,

``` tsx
<!-- Dark mode enabled -->
<html class="dark"> // ← 이부분 주목!
<body>
  <!-- Will be black -->
  <div class="bg-white dark:bg-black">
    <!-- ... -->
  </div>
</body>
</html>
```
아래와 같은 컴포넌트에서 (SSR, CSR 관계없이)
부모 컴포넌트에 "dark"라는 클래스명이 있을 때, 자식 컴포넌트의 "dark:<스타일명>"의 스타일이 발동됩니다.

저희 코드는 RootLayout 이 CSR이기 때문에 (...손봐야되긴 합니다...)
그냥 Header 컴포넌트에 `isDarkMode` State를 boolean 값으로 선언해서 관리합니다.

영향을 받는 자식 컴포넌트는 RootLayout의 `<main>` 컴포넌트입니다.

### 수정 필요한 점
- `isDarkMode`가 state이기 때문에 새로고침하면 사라집니다. localStorage에 넣어두는게 기능상 바람직한데, 더 좋은 방법이 있는지 알아봐야 합니다.
- 최종적으로 RootLayout을 SSR 컴포넌트로 바꾸긴 해야돼요. 헤더 / 푸터는 개념상 SSR로 JS 없이 HTML 상태로 렌더링 하는게 맞아보여요. 제가 초반에 리팩하다가 멈춘게 `<RecoilRoot>`이 해결이 안돼서 그랬는데, chat 리팩 끝나면 다시 손대봐야겠어요.