### PR TITLE
feat-chat: `chatMain - 채팅 이어하기` 기능 구현 & `REQUEST` 함수 param & endPoint url 조합처리  수정

### DIFF
--- a/ganoverflow-next/src/app/api/routeModule.ts
+++ b/ganoverflow-next/src/app/api/routeModule.ts
@@ -87,7 +87,10 @@ async function REQUEST({
   body?: any;
   params?: string;
 }): Promise<any> {
-  const url = params ? `${endPoint}/${params}` : endPoint;
+  const cleanedEndPoint = endPoint.endsWith("/")
+    ? endPoint.slice(0, -1)
+    : endPoint;
+  const url = params ? `${cleanedEndPoint}/${params}` : cleanedEndPoint;
 
   const response = await API.request({
     url,

--- a/ganoverflow-next/src/app/chat/api/chat.ts
+++ b/ganoverflow-next/src/app/chat/api/chat.ts
@@ -1,7 +1,11 @@
 import { POST, PUT, PATCH } from "@/app/api/routeModule";
 import { GET } from "@/app/api/routeModule";
 
-import { IChatPostSendDTO, IFolderWithPostsDTO } from "@/interfaces/chat";
+import {
+  IChatPostPutDTO,
+  IChatPostSendDTO,
+  IFolderWithPostsDTO,
+} from "@/interfaces/chat";
 import { chatPostAPI, userAPI } from "@/app/api/axiosInstanceManager";
 import { GenerateAuthHeader, IAuthData } from "@/app/api/jwt";
 
@@ -19,7 +23,26 @@ export const sendChatPost = async (
     authHeaders: GenerateAuthHeader(authData),
   });
 
-  return response;
+  return response.data;
+};
+
+export const putChatPost = async (
+  chatPostId: string | undefined,
+  chatPostBody: IChatPostPutDTO,
+  authData: IAuthData | undefined
+) => {
+  if (authData === undefined) {
+    throw new Error("authData is undefined");
+  }
+  const response = await PUT({
+    API: chatPostAPI,
+    endPoint: "/",
+    params: chatPostId,
+    body: chatPostBody,
+    authHeaders: GenerateAuthHeader(authData),
+  });
+
+  return response.data;
 };
 
 export const getAllChatPostsByUserId = async (

--- a/ganoverflow-next/src/app/chat/components/Dnd/Chatpost.tsx
+++ b/ganoverflow-next/src/app/chat/components/Dnd/Chatpost.tsx
@@ -4,7 +4,7 @@ import {
   chatpostsWithFolderstate,
   foldersWithChatpostsState,
 } from "@/atoms/folder";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import Box from "@mui/material/Box";
 import ChatIcon from "@mui/icons-material/Chat";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
@@ -20,8 +20,8 @@ import { getOneChatPostById, updateChatpostName } from "../../api/chat";
 import { accessTokenState } from "@/atoms/jwt";
 import { IAuthData } from "@/app/api/jwt";
 import useDidMountEffect from "@/hooks/useDidMountEffect";
-import { isLoadedChatState } from "@/atoms/chat";
-
+import { loadChatStatusState } from "@/atoms/chat";
+import { TLoadChatStatus } from "@/atoms/chat";
 const style: React.CSSProperties = {
   cursor: "move",
   float: "left",
@@ -47,11 +47,21 @@ export const Chatpost = function Chatpost({
     curChatpost.chatpostName
   );
   const [loadedChatPairs, setLoadedChatPairs] = useState<IChatPair[]>([]);
-  const [isLoadedChat, setIsLodedChat] = useRecoilState(isLoadedChatState);
+  const [loadChatStatus, setLoadChatStatus] =
+    useRecoilState(loadChatStatusState);
 
   // 클릭된 해당 포스트의 채팅을 로드
   useDidMountEffect(() => {
-    loadThisChatHandler(loadedChatPairs);
+    loadThisChatHandler(
+      loadedChatPairs.map((chatPair) => {
+        return {
+          question: chatPair.question,
+          answer: chatPair.answer,
+          isChecked: true,
+        };
+      }),
+      curFolderId
+    );
   }, [loadedChatPairs]);
 
   const userData = getSessionStorageItem("userData");
@@ -120,7 +130,15 @@ export const Chatpost = function Chatpost({
       authData as IAuthData
     );
 
-    setIsLodedChat(true);
+    setLoadChatStatus({
+      status: TLoadChatStatus.SHOWING,
+      loadedMeta: {
+        folderId: loadChatStatus.loadedMeta?.folderId,
+        chatPostId: curChatpost.chatPostId,
+        title: LoadedPost.chatpostName,
+        category: LoadedPost.categoryName?.categoryName,
+      },
+    });
     setLoadedChatPairs(LoadedPost.chatPair);
   };
 

--- a/ganoverflow-next/src/app/chat/components/Dnd/Chatpost.tsx
+++ b/ganoverflow-next/src/app/chat/components/Dnd/Chatpost.tsx
@@ -53,7 +53,7 @@ export const Chatpost = function Chatpost({
   // 클릭된 해당 포스트의 채팅을 로드
   useDidMountEffect(() => {
     loadThisChatHandler(
-      loadedChatPairs.map((chatPair) => {
+      loadedChatPairs?.map((chatPair) => {
         return {
           question: chatPair.question,
           answer: chatPair.answer,

--- a/ganoverflow-next/src/app/chat/components/Dnd/Container.tsx
+++ b/ganoverflow-next/src/app/chat/components/Dnd/Container.tsx
@@ -35,7 +35,7 @@ export const Container = memo(
             userId: userData.id,
           }
         );
-
+        console.log(updatedFoldersWithPosts);
         setFoldersData(updatedFoldersWithPosts); // 데이터 정합성을 위한 folder state update
       };
 
@@ -43,8 +43,6 @@ export const Container = memo(
         setIsFolderUpdated(false);
         return;
       }
-
-      console.log("useDidMount!!!!");
       updateFolders();
       setIsFolderUpdated(true);
     }, [foldersData]);

--- a/ganoverflow-next/src/app/chat/components/SaveChatModal.tsx
+++ b/ganoverflow-next/src/app/chat/components/SaveChatModal.tsx
@@ -1,4 +1,6 @@
+import { loadChatStatusState } from "@/atoms/chat";
 import { ISaveChatModalProps } from "@/interfaces/IProps/chat";
+import { useRecoilState } from "recoil";
 
 export const SaveChatModal = ({
   onChangeTitleAndCategory,
@@ -6,6 +8,9 @@ export const SaveChatModal = ({
   setIsModalOpen,
   onClickSaveChatpostExec,
 }: ISaveChatModalProps) => {
+  const [loadChatStatus, setLoadChatStatus] =
+    useRecoilState(loadChatStatusState);
+
   return (
     <div>
       <div className="fixed inset-0 bg-black opacity-50 z-20"></div>
@@ -13,12 +18,17 @@ export const SaveChatModal = ({
         <input
           className="h-11 w-full"
           onChange={onChangeTitleAndCategory}
+          defaultValue={loadChatStatus.loadedMeta?.title}
           placeholder="저장할 대화 제목을 입력해주세요"
           name="chatpostName"
         />
         <label>
           카테고리를 선택하세요
-          <select name="categoryName" onChange={onChangeTitleAndCategory}>
+          <select
+            name="category"
+            onChange={onChangeTitleAndCategory}
+            defaultValue={loadChatStatus.loadedMeta?.category}
+          >
             <option value={""}>없음</option>
             {categories.map((category, idx: number) => (
               <option key={idx}>{category.categoryName}</option>

--- a/ganoverflow-next/src/app/chat/components/chatMain.tsx
+++ b/ganoverflow-next/src/app/chat/components/chatMain.tsx
@@ -5,7 +5,7 @@ import { IChatMainProps } from "@/interfaces/IProps/chat";
 import { getAllCategories } from "../api/chat";
 import { SaveChatModal } from "./SaveChatModal";
 import { useRecoilState } from "recoil";
-import { isLoadedChatState } from "@/atoms/chat";
+import { TLoadChatStatus, loadChatStatusState } from "@/atoms/chat";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 
@@ -18,15 +18,12 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 // import { okaidia } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { gruvboxDark } from "react-syntax-highlighter/dist/esm/styles/prism"; // best
 
-interface ICategories {
-  categoryName: string;
-}
-
 export const ChatMain = ({
   onChangeTitleAndCategory,
   onChangeMessage,
   onChangeCheckBox,
   onClickNewChatBtn,
+  onClickContinueChat,
   onClickSaveChatpostInit,
   onClickSaveChatpostExec,
   onClickSubmitMsg,
@@ -37,8 +34,9 @@ export const ChatMain = ({
   scrollRef,
 }: IChatMainProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [categories, setCategories] = useState<ICategories[]>([]);
-  const [isLoadedChat, setIsLoadedChat] = useRecoilState(isLoadedChatState);
+  const [categories, setCategories] = useState<{ categoryName: string }[]>([]);
+  const [loadChatStatus, setLoadChatStatus] =
+    useRecoilState(loadChatStatusState);
 
   return (
     <div className="flex flex-col h-full">
@@ -53,14 +51,11 @@ export const ChatMain = ({
         <></>
       )}
       <div className="fixed right-36 bottom-24 z-10 hidden lg:block">
-        {isLoadedChat && (
+        {loadChatStatus.status === TLoadChatStatus.SHOWING && (
           <div className="mb-4">
             <button
               className="w-36 h-12 bg-sky-700 text-white rounded-lg"
-              onClick={() => {
-                setIsLoadedChat(false);
-                // setChatSavedStatus("F");
-              }}
+              onClick={onClickContinueChat}
             >
               채팅 이어하기
             </button>
@@ -153,15 +148,19 @@ export const ChatMain = ({
                     </div>
                   )}
                 </div>
-                <div className="checkboxContainer ml-12 w-full sm:w-3 sm:h-full">
-                  <div className="flex flex-row justify-end w-full h-full">
-                    <CircularCheckbox
-                      isDisabled={chatSavedStatus}
-                      isChecked={!!chatLine.isChecked}
-                      onChangeCheckBox={() => onChangeCheckBox(index)}
-                    />
+                {!(loadChatStatus.status === TLoadChatStatus.SHOWING) ? (
+                  <div className="checkboxContainer ml-12 w-full sm:w-3 sm:h-full">
+                    <div className="flex flex-row justify-end w-full h-full">
+                      <CircularCheckbox
+                        isDisabled={chatSavedStatus}
+                        isChecked={!!chatLine.isChecked}
+                        onChangeCheckBox={() => onChangeCheckBox(index)}
+                      />
+                    </div>
                   </div>
-                </div>
+                ) : (
+                  <></>
+                )}
               </div>
             </div>
           ))}

--- a/ganoverflow-next/src/app/chat/page.tsx
+++ b/ganoverflow-next/src/app/chat/page.tsx
@@ -45,9 +45,16 @@ export default function ChatPage() {
   const [loadChatStatus, setLoadChatStatus] =
     useRecoilState(loadChatStatusState);
 
+  // chat 첫 마운트 시, loadChatStatus 초기화
+  useEffect(() => {
+    console.log("loadChatStatus 초기화");
+    setLoadChatStatus({ status: TLoadChatStatus.F, loadedMeta: undefined });
+  }, []);
+
   // foldersData - case 1)
   useEffect(() => {
     if (accessToken) {
+      console.log("useEffect foldersData - case 1)");
       fetchFolderData(accessToken, setFoldersData, setAuthData);
     }
   }, [accessToken]);
@@ -55,6 +62,7 @@ export default function ChatPage() {
   // foldersData - case 2)
   useEffect(() => {
     if (chatSavedStatus === "T" && accessToken) {
+      console.log("useEffect foldersData - case 2)");
       fetchFolderData(accessToken, setFoldersData, setAuthData);
     }
   }, [chatSavedStatus, accessToken]);
@@ -164,7 +172,7 @@ export default function ChatPage() {
       };
       console.log("putChatPostBody", putChatPostBody);
 
-      const updatedFolders = await putChatPost(
+      await putChatPost(
         loadChatStatus.loadedMeta?.chatPostId,
         putChatPostBody,
         authData
@@ -175,7 +183,7 @@ export default function ChatPage() {
       return;
     }
 
-    const updatedFolders = await sendChatPost(chatPostBody, authData);
+    await sendChatPost(chatPostBody, authData);
     setChatSavedStatus("T");
     return;
   };
@@ -261,6 +269,7 @@ const fetchFolderData = async (
   };
   setAuthData(authData);
   const chatFoldersByUser = await getFoldersByUser(user.id, authData);
+  console.log("fetched FolderData! - 요청 후 정합성", chatFoldersByUser);
   setFoldersData(chatFoldersByUser);
 };
 

--- a/ganoverflow-next/src/atoms/chat.ts
+++ b/ganoverflow-next/src/atoms/chat.ts
@@ -1,6 +1,27 @@
 import { atom } from "recoil";
 
-export const isLoadedChatState = atom({
-  key: "isLoadedChatState",
-  default: false,
+export enum TLoadChatStatus {
+  F = "F",
+  SHOWING = "SHOWING",
+  UPDATING = "UPDATING",
+}
+
+type TLoadedMeta = {
+  folderId: number | undefined;
+  chatPostId: string | undefined;
+  title: string | undefined;
+  category: string | undefined;
+};
+
+type LoadChatStatusStateType = {
+  status: TLoadChatStatus;
+  loadedMeta?: TLoadedMeta;
+};
+
+export const loadChatStatusState = atom<LoadChatStatusStateType>({
+  key: "loadedChatStatusState",
+  default: {
+    status: TLoadChatStatus.F,
+    loadedMeta: undefined,
+  },
 });

--- a/ganoverflow-next/src/interfaces/IProps/chat.ts
+++ b/ganoverflow-next/src/interfaces/IProps/chat.ts
@@ -1,4 +1,4 @@
-import { ChatSavedStatus, IChatPair, IFolderWithPostsDTO, TLoadThisChatHandler } from "../chat";
+import { ChatSavedStatus, IChatPair, TLoadThisChatHandler } from "../chat";
 
 export interface IChatMainProps {
   onChangeTitleAndCategory: (
@@ -7,6 +7,7 @@ export interface IChatMainProps {
   onChangeMessage: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onChangeCheckBox: (index: number) => void;
   onClickNewChatBtn: (e: React.MouseEvent) => void;
+  onClickContinueChat: (e: React.MouseEvent) => void;
   onClickSaveChatpostInit: (e: React.MouseEvent) => void;
   onClickSaveChatpostExec: (e: React.MouseEvent) => void;
   onClickSubmitMsg: (e: React.FormEvent, prompt: string) => void;
@@ -20,9 +21,7 @@ export interface IChatMainProps {
 export interface IChatSideBarProps {
   onClickNewChatBtn: (e: React.MouseEvent) => void;
   chatSavedStatus: ChatSavedStatus;
-  loadThisChatHandler: TLoadThisChatHandler
-  // foldersData: IFolderWithPostsDTO[];
-  // foldersData: any;
+  loadThisChatHandler: TLoadThisChatHandler;
 }
 
 export interface IFetchStreamAnswerProps {
@@ -42,6 +41,6 @@ export interface ISaveChatModalProps {
 }
 
 export interface ITitleAndCategory {
-  chatpostName: string;
-  category?: string;
+  chatpostName: string | undefined;
+  category?: string | undefined;
 }

--- a/ganoverflow-next/src/interfaces/chat.d.ts
+++ b/ganoverflow-next/src/interfaces/chat.d.ts
@@ -11,9 +11,14 @@ export interface IChatPair {
 }
 
 export interface IChatPostSendDTO {
-  chatpostName: string;
+  chatpostName: string | undefined;
   chatPair: IChatPair[];
   category?: string;
+}
+
+// extend IChatPostSendDTO
+export interface IChatPostPutDTO extends IChatPostSendDTO {
+  folderId: number | undfined;
 }
 
 interface IFolderWithPostsDTO {
@@ -34,4 +39,7 @@ export interface ISerailzedChatposts {
   folderName: string;
 }
 
-export type TLoadThisChatHandler = (chatPairs: IChatPair[]) => void;
+export type TLoadThisChatHandler = (
+  chatPairs: IChatPair[],
+  folderId: number | undefined
+) => void;


### PR DESCRIPTION
# feat-chat: chatMain의 채팅 이어하기 기능 구현

### 1. `채팅 이어하기` 버튼으로 트리거될 `onClickContinueChat` 핸들러 함수 구현
- `채팅 이어하기` 수행 시, 관련된 상태들을 업데이트 하는 등의 작업 수행

<br>

### 2. 채팅 이어하기 후, 저장 시 `sendChatPost` 대신 평가될 `putChatPost` 요청함수 구현
- 이를 위한 `loadChatStatus` 전역상태 추가. `3가지 로드상태`, `로드 포스트 정보` 관리
- 해당 함수는, `create chatpost(=sendChatPost)`와 매우 유사하지만, `생성`이 아닌 `put`수행
- 기존 `sendChatpost`를 트리거하던 `onClickSaveChatpostExec`에서 `loadChatStatus.status`에 의해 `sendChatpost` or `putChatpost` 및 부수동작을 분기하도록 추가/수정

<br>

### 3. `saveChatModal`의 input 폼 두개 `category`, `title`에 대해 `loadChatStatus.loadedMeta`에 의해 관리되는 title, category를 `defaultValue`로 설정
- `이어하기`의 취지에 맞춰, 이어 작성하는 포스트의 기존 이름,카테고리를 인풋에 미리 넣어두도록 설정한 것

<br>

### 4: Need To Fix : #64 
채팅 이어하기 자체의 문제는 없지만, `put = 수정` 요청 집행 시 포스트 메타데이터가 비어있을 수 있다는 사실을 사용자가 인지하지 못할 수 있기 때문에 bug로 식별하였고, 추후 문제 원인 식별 및 수정 예정입니다.

<br>

### 5. 관련 BackEnd branch & PR : [Back - feat-chat: 채팅 이어하기 관련 수정 기능 chatpost - put (by Id) 구현 등](https://github.com/modulersYJ/ganoverflow-back/pull/52)

<br>

---

<br>

# feat: routeModule의 REQUEST함수의 endpoint, params 중복 /해결

기존 REQUEST함수는 `const url = params ? ${endPoint}/${params}`  모습으로 url을 생성하여 params와 `/` 중복되는 문제 존재했음 -> `endpoint`가 `/`로 끝났을 경우 제거하고 합성하도록 수정했습니다!


@hongregii 시간나실 떄 확인 한번 부탁드려요~!