### PR TITLE
feat-chat : chat - `채팅 이어하기` 기능 구현, pending된 이슈 해소에 따른 관련 최종 PR

### DIFF
--- a/ganoverflow-next/src/app/api/routeModule.ts
+++ b/ganoverflow-next/src/app/api/routeModule.ts
@@ -87,7 +87,10 @@ async function REQUEST({
   body?: any;
   params?: string;
 }): Promise<any> {
-  const url = params ? `${endPoint}/${params}` : endPoint;
+  const cleanedEndPoint = endPoint.endsWith("/")
+    ? endPoint.slice(0, -1)
+    : endPoint;
+  const url = params ? `${cleanedEndPoint}/${params}` : cleanedEndPoint;
 
   const response = await API.request({
     url,

--- a/ganoverflow-next/src/app/chat/api/chat.ts
+++ b/ganoverflow-next/src/app/chat/api/chat.ts
@@ -1,7 +1,11 @@
 import { POST, PUT, PATCH } from "@/app/api/routeModule";
 import { GET } from "@/app/api/routeModule";
 
-import { IChatPostSendDTO, IFolderWithPostsDTO } from "@/interfaces/chat";
+import {
+  IChatPostPutDTO,
+  IChatPostSendDTO,
+  IFolderWithPostsDTO,
+} from "@/interfaces/chat";
 import { chatPostAPI, userAPI } from "@/app/api/axiosInstanceManager";
 import { GenerateAuthHeader, IAuthData } from "@/app/api/jwt";
 
@@ -19,7 +23,26 @@ export const sendChatPost = async (
     authHeaders: GenerateAuthHeader(authData),
   });
 
-  return response;
+  return response.data;
+};
+
+export const putChatPost = async (
+  chatPostId: string | undefined,
+  chatPostBody: IChatPostPutDTO,
+  authData: IAuthData | undefined
+) => {
+  if (authData === undefined) {
+    throw new Error("authData is undefined");
+  }
+  const response = await PUT({
+    API: chatPostAPI,
+    endPoint: "/",
+    params: chatPostId,
+    body: chatPostBody,
+    authHeaders: GenerateAuthHeader(authData),
+  });
+
+  return response.data;
 };
 
 export const getAllChatPostsByUserId = async (

--- a/ganoverflow-next/src/app/chat/components/Dnd/Chatpost.tsx
+++ b/ganoverflow-next/src/app/chat/components/Dnd/Chatpost.tsx
@@ -4,7 +4,7 @@ import {
   chatpostsWithFolderstate,
   foldersWithChatpostsState,
 } from "@/atoms/folder";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import Box from "@mui/material/Box";
 import ChatIcon from "@mui/icons-material/Chat";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
@@ -20,8 +20,8 @@ import { getOneChatPostById, updateChatpostName } from "../../api/chat";
 import { accessTokenState } from "@/atoms/jwt";
 import { IAuthData } from "@/app/api/jwt";
 import useDidMountEffect from "@/hooks/useDidMountEffect";
-import { isLoadedChatState } from "@/atoms/chat";
-
+import { loadChatStatusState } from "@/atoms/chat";
+import { TLoadChatStatus } from "@/atoms/chat";
 const style: React.CSSProperties = {
   cursor: "move",
   float: "left",
@@ -47,11 +47,21 @@ export const Chatpost = function Chatpost({
     curChatpost.chatpostName
   );
   const [loadedChatPairs, setLoadedChatPairs] = useState<IChatPair[]>([]);
-  const [isLoadedChat, setIsLodedChat] = useRecoilState(isLoadedChatState);
+  const [loadChatStatus, setLoadChatStatus] =
+    useRecoilState(loadChatStatusState);
 
   // 클릭된 해당 포스트의 채팅을 로드
   useDidMountEffect(() => {
-    loadThisChatHandler(loadedChatPairs);
+    loadThisChatHandler(
+      loadedChatPairs.map((chatPair) => {
+        return {
+          question: chatPair.question,
+          answer: chatPair.answer,
+          isChecked: true,
+        };
+      }),
+      curFolderId
+    );
   }, [loadedChatPairs]);
 
   const userData = getSessionStorageItem("userData");
@@ -120,7 +130,15 @@ export const Chatpost = function Chatpost({
       authData as IAuthData
     );
 
-    setIsLodedChat(true);
+    setLoadChatStatus({
+      status: TLoadChatStatus.SHOWING,
+      loadedMeta: {
+        folderId: loadChatStatus.loadedMeta?.folderId,
+        chatPostId: curChatpost.chatPostId,
+        title: LoadedPost.chatpostName,
+        category: LoadedPost.categoryName?.categoryName,
+      },
+    });
     setLoadedChatPairs(LoadedPost.chatPair);
   };
 

--- a/ganoverflow-next/src/app/chat/components/Dnd/Chatpost.tsx
+++ b/ganoverflow-next/src/app/chat/components/Dnd/Chatpost.tsx
@@ -53,7 +53,7 @@ export const Chatpost = function Chatpost({
   // 클릭된 해당 포스트의 채팅을 로드
   useDidMountEffect(() => {
     loadThisChatHandler(
-      loadedChatPairs.map((chatPair) => {
+      loadedChatPairs?.map((chatPair) => {
         return {
           question: chatPair.question,
           answer: chatPair.answer,

--- a/ganoverflow-next/src/app/chat/components/Dnd/Container.tsx
+++ b/ganoverflow-next/src/app/chat/components/Dnd/Container.tsx
@@ -35,7 +35,7 @@ export const Container = memo(
             userId: userData.id,
           }
         );
-
+        console.log(updatedFoldersWithPosts);
         setFoldersData(updatedFoldersWithPosts); // 데이터 정합성을 위한 folder state update
       };
 
@@ -43,8 +43,6 @@ export const Container = memo(
         setIsFolderUpdated(false);
         return;
       }
-
-      console.log("useDidMount!!!!");
       updateFolders();
       setIsFolderUpdated(true);
     }, [foldersData]);

--- a/ganoverflow-next/src/app/chat/components/Dnd/Folder.tsx
+++ b/ganoverflow-next/src/app/chat/components/Dnd/Folder.tsx
@@ -63,7 +63,7 @@ export const Folder = ({
             <Chatpost
               curChatpost={chatpost}
               curFolderId={curFolder.folderId}
-              key={chatpost.chatPostId}
+              key={`${chatpost.chatPostId}:${chatpost.chatpostName}`}
               isDefault={true}
               loadThisChatHandler={loadThisChatHandler}
             />
@@ -77,7 +77,7 @@ export const Folder = ({
               <Chatpost
                 curChatpost={chatpost}
                 curFolderId={curFolder.folderId}
-                key={chatpost.chatPostId}
+                key={`${chatpost.chatPostId}:${chatpost.chatpostName}`}
                 isDefault={false}
                 loadThisChatHandler={loadThisChatHandler}
               />

--- a/ganoverflow-next/src/app/chat/components/SaveChatModal.tsx
+++ b/ganoverflow-next/src/app/chat/components/SaveChatModal.tsx
@@ -1,4 +1,6 @@
+import { loadChatStatusState } from "@/atoms/chat";
 import { ISaveChatModalProps } from "@/interfaces/IProps/chat";
+import { useRecoilState } from "recoil";
 
 export const SaveChatModal = ({
   onChangeTitleAndCategory,
@@ -6,6 +8,9 @@ export const SaveChatModal = ({
   setIsModalOpen,
   onClickSaveChatpostExec,
 }: ISaveChatModalProps) => {
+  const [loadChatStatus, setLoadChatStatus] =
+    useRecoilState(loadChatStatusState);
+
   return (
     <div>
       <div className="fixed inset-0 bg-black opacity-50 z-20"></div>
@@ -13,12 +18,17 @@ export const SaveChatModal = ({
         <input
           className="h-11 w-full"
           onChange={onChangeTitleAndCategory}
+          defaultValue={loadChatStatus.loadedMeta?.title}
           placeholder="저장할 대화 제목을 입력해주세요"
           name="chatpostName"
         />
         <label>
           카테고리를 선택하세요
-          <select name="categoryName" onChange={onChangeTitleAndCategory}>
+          <select
+            name="category"
+            onChange={onChangeTitleAndCategory}
+            defaultValue={loadChatStatus.loadedMeta?.category}
+          >
             <option value={""}>없음</option>
             {categories.map((category, idx: number) => (
               <option key={idx}>{category.categoryName}</option>

--- a/ganoverflow-next/src/app/chat/components/chatMain.tsx
+++ b/ganoverflow-next/src/app/chat/components/chatMain.tsx
@@ -5,7 +5,7 @@ import { IChatMainProps } from "@/interfaces/IProps/chat";
 import { getAllCategories } from "../api/chat";
 import { SaveChatModal } from "./SaveChatModal";
 import { useRecoilState } from "recoil";
-import { isLoadedChatState } from "@/atoms/chat";
+import { TLoadChatStatus, loadChatStatusState } from "@/atoms/chat";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 
@@ -18,15 +18,12 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 // import { okaidia } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { gruvboxDark } from "react-syntax-highlighter/dist/esm/styles/prism"; // best
 
-interface ICategories {
-  categoryName: string;
-}
-
 export const ChatMain = ({
   onChangeTitleAndCategory,
   onChangeMessage,
   onChangeCheckBox,
   onClickNewChatBtn,
+  onClickContinueChat,
   onClickSaveChatpostInit,
   onClickSaveChatpostExec,
   onClickSubmitMsg,
@@ -37,8 +34,9 @@ export const ChatMain = ({
   scrollRef,
 }: IChatMainProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [categories, setCategories] = useState<ICategories[]>([]);
-  const [isLoadedChat, setIsLoadedChat] = useRecoilState(isLoadedChatState);
+  const [categories, setCategories] = useState<{ categoryName: string }[]>([]);
+  const [loadChatStatus, setLoadChatStatus] =
+    useRecoilState(loadChatStatusState);
 
   return (
     <div className="flex flex-col h-full">
@@ -53,14 +51,11 @@ export const ChatMain = ({
         <></>
       )}
       <div className="fixed right-36 bottom-24 z-10 hidden lg:block">
-        {isLoadedChat && (
+        {loadChatStatus.status === TLoadChatStatus.SHOWING && (
           <div className="mb-4">
             <button
               className="w-36 h-12 bg-sky-700 text-white rounded-lg"
-              onClick={() => {
-                setIsLoadedChat(false);
-                // setChatSavedStatus("F");
-              }}
+              onClick={onClickContinueChat}
             >
               채팅 이어하기
             </button>
@@ -153,15 +148,19 @@ export const ChatMain = ({
                     </div>
                   )}
                 </div>
-                <div className="checkboxContainer ml-12 w-full sm:w-3 sm:h-full">
-                  <div className="flex flex-row justify-end w-full h-full">
-                    <CircularCheckbox
-                      isDisabled={chatSavedStatus}
-                      isChecked={!!chatLine.isChecked}
-                      onChangeCheckBox={() => onChangeCheckBox(index)}
-                    />
+                {!(loadChatStatus.status === TLoadChatStatus.SHOWING) ? (
+                  <div className="checkboxContainer ml-12 w-full sm:w-3 sm:h-full">
+                    <div className="flex flex-row justify-end w-full h-full">
+                      <CircularCheckbox
+                        isDisabled={chatSavedStatus}
+                        isChecked={!!chatLine.isChecked}
+                        onChangeCheckBox={() => onChangeCheckBox(index)}
+                      />
+                    </div>
                   </div>
-                </div>
+                ) : (
+                  <></>
+                )}
               </div>
             </div>
           ))}

--- a/ganoverflow-next/src/app/chat/components/chatMain.tsx
+++ b/ganoverflow-next/src/app/chat/components/chatMain.tsx
@@ -106,7 +106,7 @@ export const ChatMain = ({
                       <div className="overflow-auto max-w-full rounded-md">
                         <ReactMarkdown
                           components={{
-                            p({ node, children }) {
+                            p({ node, children }: any) {
                               return <p className="answer-p">{children}</p>;
                             },
                             code({
@@ -115,7 +115,7 @@ export const ChatMain = ({
                               className,
                               children,
                               ...props
-                            }) {
+                            }: any) {
                               const match = /language-(\w+)/.exec(
                                 className || ""
                               );
@@ -124,7 +124,11 @@ export const ChatMain = ({
                               if (!inline) {
                                 return (
                                   <SyntaxHighlighter
-                                    style={gruvboxDark as any}
+                                    style={
+                                      gruvboxDark as {
+                                        [key: string]: React.CSSProperties;
+                                      }
+                                    }
                                     language={language || "javascript"}
                                     PreTag="div"
                                     {...props}

--- a/ganoverflow-next/src/app/chat/page.tsx
+++ b/ganoverflow-next/src/app/chat/page.tsx
@@ -166,8 +166,19 @@ export default function ChatPage() {
     };
 
     if (loadChatStatus.status === TLoadChatStatus.UPDATING) {
+      const chatpostName =
+        titleAndCategory?.chatpostName === ""
+          ? loadChatStatus.loadedMeta?.title
+          : titleAndCategory?.chatpostName;
+      const categoryName =
+        titleAndCategory?.category === ""
+          ? loadChatStatus.loadedMeta?.category
+          : titleAndCategory?.category;
+
       const putChatPostBody = {
         ...chatPostBody,
+        chatpostName,
+        categoryName,
         folderId: loadChatStatus.loadedMeta?.folderId,
       };
       console.log("putChatPostBody", putChatPostBody);

--- a/ganoverflow-next/src/app/chat/page.tsx
+++ b/ganoverflow-next/src/app/chat/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/interfaces/IProps/chat";
 import { foldersWithChatpostsState } from "@/atoms/folder";
 import { TLoadChatStatus, loadChatStatusState } from "@/atoms/chat";
+import { useRouter } from "next/navigation";
 
 export default function ChatPage() {
   useAuthDataHook();
@@ -41,6 +42,7 @@ export default function ChatPage() {
   const [foldersData, setFoldersData] = useRecoilState<IFolderWithPostsDTO[]>(
     foldersWithChatpostsState
   );
+
   const [currStream, setCurrStream] = useState<string>("");
   const [loadChatStatus, setLoadChatStatus] =
     useRecoilState(loadChatStatusState);
@@ -164,7 +166,6 @@ export default function ChatPage() {
       categoryName: titleAndCategory?.category,
       chatPair: selectedPairs,
     };
-
     if (loadChatStatus.status === TLoadChatStatus.UPDATING) {
       const chatpostName =
         titleAndCategory?.chatpostName === ""

--- a/ganoverflow-next/src/app/chat/page.tsx
+++ b/ganoverflow-next/src/app/chat/page.tsx
@@ -45,9 +45,16 @@ export default function ChatPage() {
   const [loadChatStatus, setLoadChatStatus] =
     useRecoilState(loadChatStatusState);
 
+  // chat 첫 마운트 시, loadChatStatus 초기화
+  useEffect(() => {
+    console.log("loadChatStatus 초기화");
+    setLoadChatStatus({ status: TLoadChatStatus.F, loadedMeta: undefined });
+  }, []);
+
   // foldersData - case 1)
   useEffect(() => {
     if (accessToken) {
+      console.log("useEffect foldersData - case 1)");
       fetchFolderData(accessToken, setFoldersData, setAuthData);
     }
   }, [accessToken]);
@@ -55,6 +62,7 @@ export default function ChatPage() {
   // foldersData - case 2)
   useEffect(() => {
     if (chatSavedStatus === "T" && accessToken) {
+      console.log("useEffect foldersData - case 2)");
       fetchFolderData(accessToken, setFoldersData, setAuthData);
     }
   }, [chatSavedStatus, accessToken]);
@@ -164,7 +172,7 @@ export default function ChatPage() {
       };
       console.log("putChatPostBody", putChatPostBody);
 
-      const updatedFolders = await putChatPost(
+      await putChatPost(
         loadChatStatus.loadedMeta?.chatPostId,
         putChatPostBody,
         authData
@@ -175,7 +183,7 @@ export default function ChatPage() {
       return;
     }
 
-    const updatedFolders = await sendChatPost(chatPostBody, authData);
+    await sendChatPost(chatPostBody, authData);
     setChatSavedStatus("T");
     return;
   };
@@ -261,6 +269,7 @@ const fetchFolderData = async (
   };
   setAuthData(authData);
   const chatFoldersByUser = await getFoldersByUser(user.id, authData);
+  console.log("fetched FolderData! - 요청 후 정합성", chatFoldersByUser);
   setFoldersData(chatFoldersByUser);
 };
 

--- a/ganoverflow-next/src/atoms/chat.ts
+++ b/ganoverflow-next/src/atoms/chat.ts
@@ -1,6 +1,27 @@
 import { atom } from "recoil";
 
-export const isLoadedChatState = atom({
-  key: "isLoadedChatState",
-  default: false,
+export enum TLoadChatStatus {
+  F = "F",
+  SHOWING = "SHOWING",
+  UPDATING = "UPDATING",
+}
+
+type TLoadedMeta = {
+  folderId: number | undefined;
+  chatPostId: string | undefined;
+  title: string | undefined;
+  category: string | undefined;
+};
+
+type LoadChatStatusStateType = {
+  status: TLoadChatStatus;
+  loadedMeta?: TLoadedMeta;
+};
+
+export const loadChatStatusState = atom<LoadChatStatusStateType>({
+  key: "loadedChatStatusState",
+  default: {
+    status: TLoadChatStatus.F,
+    loadedMeta: undefined,
+  },
 });

--- a/ganoverflow-next/src/interfaces/IProps/chat.ts
+++ b/ganoverflow-next/src/interfaces/IProps/chat.ts
@@ -1,4 +1,4 @@
-import { ChatSavedStatus, IChatPair, IFolderWithPostsDTO, TLoadThisChatHandler } from "../chat";
+import { ChatSavedStatus, IChatPair, TLoadThisChatHandler } from "../chat";
 
 export interface IChatMainProps {
   onChangeTitleAndCategory: (
@@ -7,6 +7,7 @@ export interface IChatMainProps {
   onChangeMessage: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onChangeCheckBox: (index: number) => void;
   onClickNewChatBtn: (e: React.MouseEvent) => void;
+  onClickContinueChat: (e: React.MouseEvent) => void;
   onClickSaveChatpostInit: (e: React.MouseEvent) => void;
   onClickSaveChatpostExec: (e: React.MouseEvent) => void;
   onClickSubmitMsg: (e: React.FormEvent, prompt: string) => void;
@@ -20,9 +21,7 @@ export interface IChatMainProps {
 export interface IChatSideBarProps {
   onClickNewChatBtn: (e: React.MouseEvent) => void;
   chatSavedStatus: ChatSavedStatus;
-  loadThisChatHandler: TLoadThisChatHandler
-  // foldersData: IFolderWithPostsDTO[];
-  // foldersData: any;
+  loadThisChatHandler: TLoadThisChatHandler;
 }
 
 export interface IFetchStreamAnswerProps {
@@ -42,6 +41,6 @@ export interface ISaveChatModalProps {
 }
 
 export interface ITitleAndCategory {
-  chatpostName: string;
-  category?: string;
+  chatpostName: string | undefined;
+  category?: string | undefined;
 }

--- a/ganoverflow-next/src/interfaces/chat.d.ts
+++ b/ganoverflow-next/src/interfaces/chat.d.ts
@@ -11,9 +11,14 @@ export interface IChatPair {
 }
 
 export interface IChatPostSendDTO {
-  chatpostName: string;
+  chatpostName: string | undefined;
   chatPair: IChatPair[];
   category?: string;
+}
+
+// extend IChatPostSendDTO
+export interface IChatPostPutDTO extends IChatPostSendDTO {
+  folderId: number | undfined;
 }
 
 interface IFolderWithPostsDTO {
@@ -34,4 +39,7 @@ export interface ISerailzedChatposts {
   folderName: string;
 }
 
-export type TLoadThisChatHandler = (chatPairs: IChatPair[]) => void;
+export type TLoadThisChatHandler = (
+  chatPairs: IChatPair[],
+  folderId: number | undefined
+) => void;


### PR DESCRIPTION
feat-chat PR - #65 에서 `채팅 이어하기` 관련 pending되어 있던 문제 해결 추가 수정사항 반영 및 PR보냅니다!
@hongregii 

## 직전 PR 커밋 리스트
기존 커밋 관련 내용 및 논의내용은 #65 에서 확인할 수 있어요

<br>

### 1. feat-chat: chatMain의 채팅 이어하기 기능 구현

<br>

### 2. feat: routeModule의 REQUEST함수의 endpoint, params 중복 /해결

<br>

### 3. [feat-chat: 채팅 이어하기 저장의 saveChatModal 수정 없이 제출 시 공백 현상 수정](https://github.com/modulersYJ/ganoverflow-front/commit/db42400c24bb8dd8fcdd9edb28b96b247acab847)

이슈 - #64 에서 자세히 다룹니다

<br> 

### 4. 이어하기 -> 저장 한 다음에 [게시판]에 갔다 [채팅]으로 오니까 [이어하기]버튼만 남아있는 현상 수정

<br><br>

---

<br><br>


## 추가 변경점 (pending 이슈 해소)

### 1. [feat-chat: 채팅 이어하기 - 저장에 따른 상태변화가 렌더링 반영되지 않던 문제해결](https://github.com/modulersYJ/ganoverflow-front/commit/c6ccce1bd94babec808979ee9e0b280d1fd176bc)

![image](https://github.com/modulersYJ/ganoverflow-front/assets/65459616/85312baa-273b-4a86-a4a1-9c43dc5fdda5)


이슈 - #67 에서 원인 규명 및 해결에 관한 자세한 내용을 다룹니다잉

<br><br>

### 2. [feat-chat: react-markdown을 사용한 부분 간이 타입 명시](https://github.com/modulersYJ/ganoverflow-front/commit/68a0815660465c7948ac417276a63a75beef1216)

타입 관련 자잘한 수정사항이에요