### PR TITLE
feat-chatContext: GPT 대화 맥락기억 모드 추가, 함수형 기반 `ChatGPTMessageChain` 및 체이닝 함수 구현

### DIFF
--- a/ganoverflow-next/src/app/chat/ChatMain/components/ChatContent/components/ChatPairWrapper.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/components/ChatContent/components/ChatPairWrapper.tsx
@@ -8,7 +8,7 @@ const ChatPairWrapper = ({
   return (
     <div
       key={index}
-      className={`w-full py-5 ${
+      className={`w-full py-5 dark:border-b-2 border-b-[#2c2c33] ${
         index % 2 === 0
           ? "bg-gray-300 dark:bg-[#2c2c33]"
           : "bg-gray-200 dark:bg-[#202024]" // 홀짝 배경색 변경

--- a/ganoverflow-next/src/app/chat/ChatMain/components/PromptConsole/handlers.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/components/PromptConsole/handlers.tsx
@@ -1,7 +1,13 @@
 import { fetchUpdateStreamAnswer } from "@/app/chat/api/chat";
 import { chatPairsState, questionInputState } from "@/atoms/chat";
+import { IChatPair } from "@/interfaces/chat";
+import {
+  ChatGPTAgent,
+  ChatGPTMessage,
+  ChatGPTMessageChain,
+} from "@/utils/openAI/chatGPT";
 import { Dispatch, FormEvent, SetStateAction } from "react";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import { useRecoilState } from "recoil";
 
 export const GetHandleQuestionInput = (setQuestionInput: any) => {
   return (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -9,16 +15,29 @@ export const GetHandleQuestionInput = (setQuestionInput: any) => {
   };
 };
 
-export const GetHandleSubmitMsg = (
-  isNowAnswering: boolean,
-  currStream: string,
-  setIsNowAnswering: Dispatch<SetStateAction<boolean>>,
-  setCurrStream: Dispatch<SetStateAction<string>>
-) => {
+export const GetHandleSubmitMsg = ({
+  isNowAnswering,
+  currStream,
+  setIsNowAnswering,
+  setCurrStream,
+}: {
+  isNowAnswering: boolean;
+  currStream: string;
+  setIsNowAnswering: Dispatch<SetStateAction<boolean>>;
+  setCurrStream: Dispatch<SetStateAction<string>>;
+}) => {
   const [questionInput, setQuestionInput] = useRecoilState(questionInputState);
-  const setChatPairs = useSetRecoilState(chatPairsState);
+  const [chatPairs, setChatPairs] = useRecoilState(chatPairsState);
 
-  return async (e: FormEvent, prompt: string) => {
+  return async ({
+    e,
+    prompt,
+    isContextMode,
+  }: {
+    e: FormEvent;
+    prompt: string;
+    isContextMode: boolean;
+  }) => {
     e.preventDefault();
     if (isNowAnswering) {
       alert("답변중에는 질문할 수 없습니다!");
@@ -32,7 +51,17 @@ export const GetHandleSubmitMsg = (
     setQuestionInput("");
     setCurrStream(""); // 초기화
 
-    // 사용자 질문만 업데이트 및 마운트
+    // 맥락모드 에 따른 대화 구성 (함수형 프로그래밍 기반 체이닝 방식 구현)
+    const promptsChain = isContextMode
+      ? composePromptsForContext(prompt, chatPairs)
+      : new ChatGPTMessageChain().pushChat(ChatGPTAgent.user, prompt);
+
+    const cmdTypeCute = "Say cutely";
+    const cmdLanguageKorean = "Answer in Korean";
+    const systemCmds = [cmdLanguageKorean]; // system command 적용
+    const prompts = promptsChain.appendSystemCommands(systemCmds).get();
+
+    // 사용자 질문만 먼저 업데이트 -> view에 마운트
     setChatPairs((prevChat: any) => [
       ...prevChat,
       {
@@ -41,11 +70,31 @@ export const GetHandleSubmitMsg = (
         isChecked: false,
       },
     ]);
+
     await fetchUpdateStreamAnswer({
-      prompt,
+      prompts,
       currStream,
       setCurrStream,
       setIsNowAnswering,
     });
   };
+};
+
+const composePromptsForContext = (
+  prompt: string,
+  chatPairs: IChatPair[]
+): ChatGPTMessageChain => {
+  const promptsChain = new ChatGPTMessageChain();
+
+  // 사전 대화들을 맥락에 추가
+  chatPairs.forEach((chatPair) => {
+    promptsChain.pushChatPairs(chatPair.question, chatPair.answer);
+  });
+
+  // 마지막으로 주어진 prompt를 user로 추가
+  promptsChain.pushChat(ChatGPTAgent.user, prompt);
+
+  console.log("chatPairs!!!: ", chatPairs);
+  console.log("prompts!!!: ", ...promptsChain.get());
+  return promptsChain;
 };

--- a/ganoverflow-next/src/app/chat/ChatMain/components/PromptConsole/handlers.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/components/PromptConsole/handlers.tsx
@@ -3,7 +3,6 @@ import { chatPairsState, questionInputState } from "@/atoms/chat";
 import { IChatPair } from "@/interfaces/chat";
 import {
   ChatGPTAgent,
-  ChatGPTMessage,
   ChatGPTMessageChain,
 } from "@/utils/openAI/chatGPT";
 import { Dispatch, FormEvent, SetStateAction } from "react";

--- a/ganoverflow-next/src/app/chat/ChatMain/components/PromptConsole/index.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/components/PromptConsole/index.tsx
@@ -29,12 +29,12 @@ const PromptConsole = ({
   const chatSavedStatus = useRecoilValue(chatSavedStatusState);
   const setChatPairs = useSetRecoilState(chatPairsState);
 
-  const onClickSubmitMsg = GetHandleSubmitMsg(
+  const onClickSubmitMsg = GetHandleSubmitMsg({
     isNowAnswering,
     currStream,
     setIsNowAnswering,
-    setCurrStream
-  );
+    setCurrStream,
+  });
   const onChangeQuestionInput = GetHandleQuestionInput(setQuestionInput);
 
   // UPDATE states, using streaming answer
@@ -56,7 +56,7 @@ const PromptConsole = ({
     <div className="promptConsole h-20 fixed bottom-0 w-full flex items-center justify-center opacity-95 backdrop-blur-sm backdrop-saturate-100 bg-vert-light-gradient dark:bg-transparent dark:bg-vert-dark-gradient">
       <form
         onSubmit={(e) => {
-          onClickSubmitMsg(e, questionInput);
+          onClickSubmitMsg({ e, prompt: questionInput, isContextMode: true });
         }}
         className="w-full max-w-[40%] mr-12 md:mr-0 flex items-center "
       >

--- a/ganoverflow-next/src/app/chat/api/chat.ts
+++ b/ganoverflow-next/src/app/chat/api/chat.ts
@@ -160,7 +160,7 @@ export const updateChatpostName = async (
 
 // No need to cache
 export const fetchUpdateStreamAnswer = async ({
-  prompt,
+  prompts,
   currStream,
   setCurrStream,
   setIsNowAnswering,
@@ -171,7 +171,7 @@ export const fetchUpdateStreamAnswer = async ({
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      prompt,
+      prompts,
     }),
   });
 

--- a/ganoverflow-next/src/app/chat/api/route.ts
+++ b/ganoverflow-next/src/app/chat/api/route.ts
@@ -1,21 +1,22 @@
-import { OpenAIStream, OpenAIStreamPayload } from "@/utils/openAIStream";
+import { ChatGPTMessage } from "@/utils/openAI/chatGPT";
+import { OpenAIStream, OpenAIStreamPayload } from "@/utils/openAI/openAIStream";
 
 if (!process.env.OPENAI_API_KEY) {
   throw new Error("Missing env var from OpenAI");
 }
 
 export async function POST(req: Request): Promise<Response> {
-  const { prompt } = (await req.json()) as {
-    prompt?: string;
+  const { prompts } = (await req.json()) as {
+    prompts?: ChatGPTMessage[];
   };
 
-  if (!prompt) {
-    return new Response("No prompt in the request", { status: 400 });
+  if (!prompts) {
+    return new Response("No prompts in the request", { status: 400 });
   }
 
   const payload: OpenAIStreamPayload = {
     model: "gpt-3.5-turbo",
-    messages: [{ role: "user", content: prompt }],
+    messages: prompts,
     temperature: 0.7,
     top_p: 1,
     frequency_penalty: 0,

--- a/ganoverflow-next/src/app/layout.tsx
+++ b/ganoverflow-next/src/app/layout.tsx
@@ -60,7 +60,7 @@ export default function RootLayout({
       <RecoilRoot>
         <body className="flex min-h-full flex-col">
           <Header toggleDarkMode={toggleDarkMode} isDarkMode={isDarkMode} />
-          <main className="grow pt-[44px] md:pt-[68px] bg-light dark:bg-[#202024] dark:text-slate-100 dark:bg-vert-dark-gradient">
+          <main className="grow pt-[44px] md:pt-[68px] bg-light dark:bg-[#202024] dark:text-slate-100">
             {children}
           </main>
           {/* {!offFooter &&  */}
@@ -143,7 +143,7 @@ const Header = ({
   return (
     <header>
       <nav className="header-nav shadow-headerBox fixed w-full top-0 z-50">
-        <div className="container mx-auto px-6 py-1 flex justify-between">
+        <div className="mx-auto px-6 py-1 flex justify-between">
           <div className="flex items-center col-span-1">
             <Link href="/" passHref>
               <Image

--- a/ganoverflow-next/src/interfaces/IProps/chat.ts
+++ b/ganoverflow-next/src/interfaces/IProps/chat.ts
@@ -1,6 +1,5 @@
 import { IAuthData } from "@/app/api/jwt";
-import { ChatSavedStatus, IChatPair, TLoadThisChatHandler } from "../chat";
-import { ChatGPTAgent, ChatGPTMessage } from "@/utils/openAI/openAIStream";
+import { ChatGPTMessage } from "@/utils/openAI/chatGPT";
 
 export interface IChatMainProps {
   authData: IAuthData | undefined;

--- a/ganoverflow-next/src/interfaces/IProps/chat.ts
+++ b/ganoverflow-next/src/interfaces/IProps/chat.ts
@@ -1,5 +1,6 @@
 import { IAuthData } from "@/app/api/jwt";
 import { ChatSavedStatus, IChatPair, TLoadThisChatHandler } from "../chat";
+import { ChatGPTAgent, ChatGPTMessage } from "@/utils/openAI/openAIStream";
 
 export interface IChatMainProps {
   authData: IAuthData | undefined;
@@ -11,8 +12,14 @@ export interface IChatSideBarProps {
   onClickNewChatBtn: (e: React.MouseEvent) => void;
 }
 
+export enum TPromptRole {
+  user = "user",
+  assistant = "assistant",
+  system = "system",
+}
+
 export interface IFetchStreamAnswerProps {
-  prompt: string;
+  prompts: ChatGPTMessage[];
   currStream: string;
   setCurrStream: any;
   setIsNowAnswering: any;

--- a/ganoverflow-next/src/utils/openAI/chatGPT.ts
+++ b/ganoverflow-next/src/utils/openAI/chatGPT.ts
@@ -1,0 +1,49 @@
+export enum ChatGPTAgent {
+  user = "user",
+  assistant = "assistant",
+  system = "system",
+}
+
+export interface ChatGPTMessage {
+  role: ChatGPTAgent;
+  content: string;
+}
+
+// 함수형 기반 구현
+export class ChatGPTMessageChain {
+  constructor(private messages: ChatGPTMessage[] = []) {}
+
+  appendSystemCommands(systemCmds: string[]): ChatGPTMessageChain {
+    systemCmds.forEach((cmd) => {
+      this.messages.push({
+        role: ChatGPTAgent.system,
+        content: cmd,
+      });
+    });
+    return this;
+  }
+
+  pushChatPairs(userMsg: string, assistantMsg: string): ChatGPTMessageChain {
+    this.messages.push({
+      role: ChatGPTAgent.user,
+      content: userMsg,
+    });
+    this.messages.push({
+      role: ChatGPTAgent.assistant,
+      content: assistantMsg,
+    });
+    return this;
+  }
+
+  pushChat(role: ChatGPTAgent, content: string): ChatGPTMessageChain {
+    this.messages.push({
+      role: role,
+      content: content,
+    });
+    return this;
+  }
+
+  get(): ChatGPTMessage[] {
+    return this.messages;
+  }
+}

--- a/ganoverflow-next/src/utils/openAI/openAIStream.ts
+++ b/ganoverflow-next/src/utils/openAI/openAIStream.ts
@@ -1,15 +1,9 @@
+import { ChatGPTMessage } from "./chatGPT";
 import {
   createParser,
   ParsedEvent,
   ReconnectInterval,
 } from "eventsource-parser";
-
-export type ChatGPTAgent = "user" | "system";
-
-export interface ChatGPTMessage {
-  role: ChatGPTAgent;
-  content: string;
-}
 
 export interface OpenAIStreamPayload {
   model: string;


### PR DESCRIPTION
@hongregii 
맥락기억모드 추가했습니다만.. 토큰 사용량이 몇배로 늘어나게 될 예정이라 #82 적용해서 빠르게 고도화해봐야 할 것 같습니다ㅋ.ㅋ.ㅋ. 추가로, 위협을 좀 느껴서 #93 을 통해 수익전략도 고민해보고있습니다ㅋㅋㅋ 참고해주세요

사용법은 1번에 언급된 `GetHandleSubmitMsg`로 받은 onClickSubmitMsg 핸들러에 `isContext`만 true로 주면 됩니다잉

 
#### 맥락 기억모드 off
![gof-0819-contextChat-off](https://github.com/modulersYJ/ganoverflow-front/assets/65459616/182b7e41-61f8-4025-b624-ae843ca04ab7)

#### 맥락 기억모드 on
![gof-0819-contextChat-on](https://github.com/modulersYJ/ganoverflow-front/assets/65459616/7f42d4d4-7002-4116-b1b4-54a4c8a3e579)

#### system command ("say cutely") 활성화
![gof-0819-systemCmds](https://github.com/modulersYJ/ganoverflow-front/assets/65459616/d55be8f6-ac9b-4c57-8ea8-6b0ca2ce9b9f)


### 1. `GetHandleSubmitMsg` 기억 모드 추가 & 시스템 명령 프롬프트 적용
- 채팅 제출 핸들러 함수의 인자 `isContextMode` boolean에 의한 기억모드 추가

- 단일 문자열 prompt를 엔드포인트 openAI요청에 담아 보내던 것을 `ChatGPTMessage[]`로 구성하여 보내도록 수정

- 기억 모드 활성 시, ChatPairs state로 유지한 기존 대화를 ``ChatGPTMessage[]`에 사전 구성

- systemCommand 커스텀 적용 기능 추가

<br><br>

### 2. chatGPT.ts에 `class ChatGPTMessageChain` 함수형 기반 클래스 및 체이닝 함수 정의
- appendSystemCommands

- pushChatPairs

- pushChat

<br><br>

### 3. 기타 작업
- 헤더 레이아웃 수정

- 다크모드 페이지의 기본 bg-vert-gradient 제거

- 다크모드 시 ChatPairWrapper, border-bottom 색상 주어 기본 배경색과 구분성 제고

<br><br>

after ) 시스템 커스텀 설정 추가 고민
- 사용자 설정 가능하게 해볼까?