### PR TITLE
feat-chatBubbleStyle: tailwind animate popIn 확장 & 대화 말풍선, LoginBoxModal, SaveChatModal, 채팅 저장하기 에 적용

### DIFF
--- a/ganoverflow-next/src/app/accounts/login/LoginBoxModal.tsx
+++ b/ganoverflow-next/src/app/accounts/login/LoginBoxModal.tsx
@@ -7,7 +7,7 @@ export const LoginBoxModal = () => {
 
   return (
     <div className="LoginBoxModal z-30 fixed inset-0 flex justify-center items-center">
-      <div className="z-30 relative max-w-lg">
+      <div className="z-30 relative max-w-lg animate-popIn origin-bottom">
         <LoginBox modalType />
       </div>
       <div

--- a/ganoverflow-next/src/app/chat/ChatMain/components/ChatContent/components/MsgBox.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/components/ChatContent/components/MsgBox.tsx
@@ -1,9 +1,11 @@
 const MsgBox = ({ children, isQuestion }: any) => {
   const styleClass = isQuestion
-    ? "rounded-chat-question bg-primary text-white self-end"
-    : "rounded-chat-answer bg-gray-500 text-white self-start";
+    ? "rounded-chat-question bg-primary text-white self-end origin-bottom-right"
+    : "rounded-chat-answer bg-gray-500 text-white self-start origin-bottom-left";
   return (
-    <div className={`msgBox mt-4 p-5 max-w-sm text-xs ${styleClass}`}>
+    <div
+      className={`msgBox mt-4 p-5 max-w-sm text-xs animate-popIn ${styleClass}`}
+    >
       {children}
     </div>
   );

--- a/ganoverflow-next/src/app/chat/ChatMain/components/ChatContent/index.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/components/ChatContent/index.tsx
@@ -27,7 +27,7 @@ const ChatContent = ({ scrollRef }: any) => {
     <div className="chatCont flex-grow overflow-y-auto flex justify-center mb-[96px]">
       <div className="chatBox w-full" ref={scrollRef}>
         {chatPairs?.map((chatLine: IChatPair, index: number) => (
-          <ChatPairWrapper key={index} index={index}>
+          <ChatPairWrapper key={`${index}:${chatLine.question}`} index={index}>
             <div className="chatPairBox w-full flex flex-col justify-center self-center">
               {chatLine.question && (
                 <MsgBox isQuestion={true}>{chatLine.question}</MsgBox>

--- a/ganoverflow-next/src/app/chat/ChatMain/components/ChatControlBtns/BtnSubmitSaveChat.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/components/ChatControlBtns/BtnSubmitSaveChat.tsx
@@ -13,7 +13,7 @@ export const BtnSubmitSaveChat = ({
     <div>
       {checkCnt > 0 ? (
         <button
-          className="rounded-3xl bg-gray-100 dark:bg-gray-700 h-14 flex flex-col justify-center opacity-85 "
+          className="rounded-3xl animate-popIn origin-bottom bg-gray-100 dark:bg-gray-700 h-14 flex flex-col justify-center opacity-85 "
           onClick={async (e) => {
             onClickHandler(e);
             setCategories(await getAllCategories());

--- a/ganoverflow-next/src/app/chat/ChatMain/components/ChatControlBtns/handlers.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/components/ChatControlBtns/handlers.tsx
@@ -16,15 +16,23 @@ export const GetHandleSaveChatpostInit = (
   };
 };
 
-export const GetHandleContinueChat = (
-  loadChatStatus: any,
-  chatPairs: SetterOrUpdater<IChatPair[]>,
-  setLoadChatStatus: SetterOrUpdater<any>,
-  setCheckCnt: SetterOrUpdater<number>,
-  setChatSavedStatus: SetterOrUpdater<ChatSavedStatus>,
-  setQuestionInput: SetterOrUpdater<string>
-) => {
+export const GetHandleContinueChat = ({
+  loadChatStatus,
+  chatPairs,
+  setLoadChatStatus,
+  setCheckCnt,
+  setChatSavedStatus,
+  setQuestionInput,
+}: {
+  loadChatStatus: any;
+  chatPairs: IChatPair[];
+  setLoadChatStatus: SetterOrUpdater<any>;
+  setCheckCnt: SetterOrUpdater<number>;
+  setChatSavedStatus: SetterOrUpdater<ChatSavedStatus>;
+  setQuestionInput: SetterOrUpdater<string>;
+}) => {
   return () => {
+    console.log("채팅 이어하기 - chatPairs!", chatPairs);
     setLoadChatStatus({
       status: TLoadChatStatus.UPDATING,
       loadedMeta: {

--- a/ganoverflow-next/src/app/chat/ChatMain/components/ChatControlBtns/index.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/components/ChatControlBtns/index.tsx
@@ -7,7 +7,7 @@ import {
   questionInputState,
 } from "@/atoms/chat";
 import { BtnSubmitSaveChat } from "./BtnSubmitSaveChat";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { GetHandleContinueChat, GetHandleSaveChatpostInit } from "./handlers";
 import { Dispatch, SetStateAction } from "react";
 
@@ -33,21 +33,22 @@ const ChatControlsBtns = ({
   const [loadChatStatus, setLoadChatStatus] =
     useRecoilState(loadChatStatusState);
   const [checkCnt, setCheckCnt] = useRecoilState(checkCntState);
-  const chatPairs = useSetRecoilState(chatPairsState);
+  const chatPairs = useRecoilValue(chatPairsState);
   const setQuestionInput = useSetRecoilState(questionInputState);
 
   const onClickSaveChatpostInit = GetHandleSaveChatpostInit(
     isNowAnswering,
     setChatSavedStatus
   );
-  const onClickContinueChat = GetHandleContinueChat(
+
+  const onClickContinueChat = GetHandleContinueChat({
     loadChatStatus,
     chatPairs,
     setLoadChatStatus,
     setCheckCnt,
     setChatSavedStatus,
-    setQuestionInput
-  );
+    setQuestionInput,
+  });
 
   return (
     <div className="fixed right-36 bottom-24 z-10 hidden lg:block">

--- a/ganoverflow-next/src/app/chat/ChatMain/components/PromptConsole/handlers.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/components/PromptConsole/handlers.tsx
@@ -58,8 +58,8 @@ export const GetHandleSubmitMsg = ({
 
     const cmdTypeCute = "Say cutely";
     const cmdLanguageKorean = "Answer in Korean";
-    const systemCmds = [cmdLanguageKorean]; // system command 적용
-    const prompts = promptsChain.appendSystemCommands(systemCmds).get();
+    const systemCmds = []; // system command 적용
+    const prompts = promptsChain.get(); // .appendSystemCommands(systemCmds).get();
 
     // 사용자 질문만 먼저 업데이트 -> view에 마운트
     setChatPairs((prevChat: any) => [

--- a/ganoverflow-next/src/app/chat/ChatMain/components/PromptConsole/index.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/components/PromptConsole/index.tsx
@@ -56,7 +56,7 @@ const PromptConsole = ({
     <div className="promptConsole h-20 fixed bottom-0 w-full flex items-center justify-center opacity-95 backdrop-blur-sm backdrop-saturate-100 bg-vert-light-gradient dark:bg-transparent dark:bg-vert-dark-gradient">
       <form
         onSubmit={(e) => {
-          onClickSubmitMsg({ e, prompt: questionInput, isContextMode: true });
+          onClickSubmitMsg({ e, prompt: questionInput, isContextMode: false });
         }}
         className="w-full max-w-[40%] mr-12 md:mr-0 flex items-center "
       >

--- a/ganoverflow-next/src/app/chat/ChatMain/components/SaveChatModal/index.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/components/SaveChatModal/index.tsx
@@ -53,7 +53,7 @@ const SaveChatModal = ({
   return (
     <div>
       <div className="fixed inset-0 bg-black opacity-40 z-20"></div>
-      <dialog className="fixed bg-gray-100 dark:bg-black top-1/4 flex flex-col w-1/3 justify-between gap-6 px-20 py-10 outline-none text-lg font-semibold rounded-md z-30">
+      <dialog className="fixed animate-popIn origin-bottom bg-gray-100 dark:bg-black top-1/4 flex flex-col w-1/3 justify-between gap-6 px-20 py-10 outline-none text-lg font-semibold rounded-md z-30">
         <h2 className="tw-subtitle">채팅 저장하기</h2>
         <div className="flex flex-col gap-2 mt-5">
           <label className="text-sm text-left">제목</label>

--- a/ganoverflow-next/src/app/chat/ChatSideBar/components/DragDropContainer/index.tsx
+++ b/ganoverflow-next/src/app/chat/ChatSideBar/components/DragDropContainer/index.tsx
@@ -52,13 +52,14 @@ const DragDropContainer = memo(() => {
     <div className="list-container overflow-y-auto h-screen pb-[200px]">
       <DndProvider backend={HTML5Backend}>
         <div className="clear-both flex flex-col">
-          {foldersData?.map((folder: IFolderWithPostsDTO, idx: number) => (
-            <FolderDroppable
-              curFolder={folder}
-              key={folder.folderId}
-              idx={idx}
-            />
-          ))}
+          {Array.isArray(foldersData) &&
+            foldersData.map((folder: IFolderWithPostsDTO, idx: number) => (
+              <FolderDroppable
+                curFolder={folder}
+                key={folder.folderId}
+                idx={idx}
+              />
+            ))}
         </div>
       </DndProvider>
     </div>

--- a/ganoverflow-next/tailwind.config.js
+++ b/ganoverflow-next/tailwind.config.js
@@ -48,6 +48,15 @@ module.exports = {
         "chat-question": "20px 20px 0px 20px",
         "chat-answer": "20px 20px 20px 0px",
       },
+      keyframes: {
+        popIn: {
+          "0%": { transform: "scale(0)" },
+          "100%": { transform: "scale(1)" },
+        },
+      },
+      animation: {
+        popIn: "popIn 0.1s ease-out",
+      },
     },
     plugins: [],
     variants: {


### PR DESCRIPTION
@hongregii 간단한 스타일 확장 및 적용 관련이에요! gif만 확인하셔도 무방합니다

### 1. tailwind.config.ts의 animate에 popIn 애니메이션 확장

### 2. `대화 말풍선`, `LoginBoxModal`, `SaveChatModal`, `채팅 저장하기 버튼`에 popIn 적용

#### 로그인 모달
![gof-0820-popIn-loginModal](https://github.com/modulersYJ/ganoverflow-front/assets/65459616/c086383c-d1d8-4ee5-8c53-57e90a2ac3eb)

#### 대화 말풍선
![gof-0820-popIn-chatBubbole](https://github.com/modulersYJ/ganoverflow-front/assets/65459616/7c076b37-41d5-4f66-9fa2-4b65542ff6aa)

#### 채팅 저장하기 버튼 & saveChatModal
![gof-0820-popIn-saveChat](https://github.com/modulersYJ/ganoverflow-front/assets/65459616/0616026c-0067-42a6-bbeb-45594860137d)

### 3. 기타 fix: DragDropContainer에서 foldersData가 Array가 아닌 경우(기존에 accessToken 만료 시) 렌더 X 예외처리

