### PR TITLE
feat-deleteFuncsInChat: Chat의 사이드바를 통한 포스트,폴더 삭제 로직 수정 & 관련 요청함수 구현 등

### DIFF
--- a/ganoverflow-next/src/app/api/routeModule.ts
+++ b/ganoverflow-next/src/app/api/routeModule.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance, Method } from "axios";
+import { AxiosInstance } from "axios";
 
 export async function GET(
   endPoint: string,
@@ -71,6 +71,23 @@ export function PATCH({
   return REQUEST({ API, method: "PATCH", endPoint, body, authHeaders, params });
 }
 
+export function DELETE({
+  API,
+  endPoint,
+  authHeaders,
+  body,
+  params,
+}: IUpdateReqProps): Promise<any> {
+  return REQUEST({
+    API,
+    method: "DELETE",
+    endPoint,
+    body,
+    authHeaders,
+    params,
+  });
+}
+
 // POST, PUT, PATCH의 평가부 추상화
 async function REQUEST({
   API,
@@ -81,7 +98,7 @@ async function REQUEST({
   params,
 }: {
   API: AxiosInstance;
-  method: "POST" | "PUT" | "PATCH";
+  method: "POST" | "PUT" | "PATCH" | "DELETE";
   endPoint: string;
   authHeaders?: any;
   body?: any;

--- a/ganoverflow-next/src/app/chat/ChatSideBar/components/DragDropContainer/FolderDroppable/components/ChatpostDraggable/handlers.tsx
+++ b/ganoverflow-next/src/app/chat/ChatSideBar/components/DragDropContainer/FolderDroppable/components/ChatpostDraggable/handlers.tsx
@@ -1,5 +1,9 @@
 import { useDrag } from "react-dnd";
-import { getOneChatPostById, updateChatpostName } from "@/app/chat/api/chat";
+import {
+  deleteChatpost,
+  getOneChatPostById,
+  updateChatpostName,
+} from "@/app/chat/api/chat";
 import { IAuthData } from "@/app/api/jwt";
 import { TLoadChatStatus } from "@/atoms/chat";
 import {
@@ -60,25 +64,25 @@ const getHandleUpdateChatpostName =
   };
 
 const getHandleDeleteChatpost =
-  (
-    curChatpost: IChatPostBasicInfo,
-    folderId: IFolderWithPostsDTO["folderId"],
-    folders: IFolderWithPostsDTO[],
-    setFolders: React.Dispatch<React.SetStateAction<IFolderWithPostsDTO[]>>
-  ) =>
-  () => {
-    setFolders(
-      folders.map((folder) =>
-        folder.folderId === folderId
-          ? {
-              ...folder,
-              chatposts: folder.chatposts.filter(
-                (chatpost) => curChatpost.chatPostId !== chatpost.chatPostId
-              ),
-            }
-          : { ...folder }
-      )
-    );
+  ({
+    authData,
+    curChatpost,
+    setFolders,
+  }: {
+    authData: IAuthData;
+    curChatpost: IChatPostBasicInfo;
+    setFolders: React.Dispatch<React.SetStateAction<IFolderWithPostsDTO[]>>;
+  }) =>
+  async () => {
+    try {
+      const updatedFolders = await deleteChatpost({
+        authData,
+        chatpostId: curChatpost.chatPostId,
+      });
+      setFolders(updatedFolders);
+    } catch (error: any) {
+      alert(error.message);
+    }
   };
 
 const getHandleLoadThisPost =

--- a/ganoverflow-next/src/app/chat/ChatSideBar/components/DragDropContainer/FolderDroppable/components/ChatpostDraggable/index.tsx
+++ b/ganoverflow-next/src/app/chat/ChatSideBar/components/DragDropContainer/FolderDroppable/components/ChatpostDraggable/index.tsx
@@ -72,12 +72,11 @@ const ChatpostDraggable: React.FC<IChatpostDraggableProps> = ({
     setChatpostName,
     setFoldersWithPosts
   );
-  const onClickDeleteChatpostBtn = getHandleDeleteChatpost(
+  const onClickDeleteChatpostBtn = getHandleDeleteChatpost({
+    authData,
     curChatpost,
-    curFolderId,
-    foldersWithPosts,
-    setFoldersWithPosts
-  );
+    setFolders: setFoldersWithPosts,
+  });
   const onClickLoadThisPost = getHandleLoadThisPost(
     curChatpost,
     authData,

--- a/ganoverflow-next/src/app/chat/ChatSideBar/components/DragDropContainer/FolderDroppable/components/CustomFolder/handlers.tsx
+++ b/ganoverflow-next/src/app/chat/ChatSideBar/components/DragDropContainer/FolderDroppable/components/CustomFolder/handlers.tsx
@@ -1,3 +1,5 @@
+import { IAuthData } from "@/app/api/jwt";
+import { deleteChatpostsByFolder } from "@/app/chat/api/chat";
 import { IFolderWithPostsDTO } from "@/interfaces/chat";
 import { Dispatch, SetStateAction } from "react";
 import { SetterOrUpdater } from "recoil";
@@ -26,12 +28,19 @@ export const getToggleDeleteBtnShowHandler =
   };
 
 export const getDeleteFolderHandler =
-  (
-    setFoldersWithPosts: SetterOrUpdater<IFolderWithPostsDTO[]>,
-    curFolder: IFolderWithPostsDTO
-  ) =>
-  () => {
-    setFoldersWithPosts((prev) =>
-      prev.filter((folder) => folder.folderId !== curFolder.folderId)
-    );
+  ({
+    authData,
+    curFolderId,
+    setFoldersWithPosts,
+  }: {
+    authData: IAuthData;
+    curFolderId: IFolderWithPostsDTO["folderId"];
+    setFoldersWithPosts: SetterOrUpdater<IFolderWithPostsDTO[]>;
+  }) =>
+  async () => {
+    const updatedFolder = await deleteChatpostsByFolder({
+      authData,
+      folderId: curFolderId,
+    });
+    setFoldersWithPosts(updatedFolder);
   };

--- a/ganoverflow-next/src/app/chat/ChatSideBar/components/DragDropContainer/FolderDroppable/components/CustomFolder/index.tsx
+++ b/ganoverflow-next/src/app/chat/ChatSideBar/components/DragDropContainer/FolderDroppable/components/CustomFolder/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { IFolderWithPostsDTO } from "@/interfaces/chat";
 import { foldersWithChatpostsState } from "@/atoms/folder";
 import TitleEdit from "@/components/ui/Chat/TitleEdit";
@@ -15,12 +15,21 @@ import {
   FolderUtilityButtons,
   TFolderBtnProps,
 } from "./components";
+import { getSessionStorageItem } from "@/utils/common/sessionStorage";
+import { accessTokenState } from "@/atoms/jwt";
 
 const CustomFolder: React.FC<{
   curFolder: IFolderWithPostsDTO;
   isFolderSpread: boolean;
   onClickToggleFolderSpread: any;
 }> = ({ curFolder, isFolderSpread, onClickToggleFolderSpread }) => {
+  const userData = getSessionStorageItem("userData");
+  const accessToken = useRecoilValue(accessTokenState);
+  const authData = {
+    accessToken,
+    userId: userData?.id,
+  };
+
   const [isDeleteFolderClicked, setIsDeleteFolderClicked] =
     useState<boolean>(false);
   const [folderName, setFolderName] = useState<string>(curFolder.folderName);
@@ -45,7 +54,11 @@ const CustomFolder: React.FC<{
     isDeleteFolderClicked,
     setFoldersWithPosts,
     foldersWithPosts,
-    onClickDeleteFolder: getDeleteFolderHandler(setFoldersWithPosts, curFolder),
+    onClickDeleteFolder: getDeleteFolderHandler({
+      authData,
+      curFolderId: curFolder.folderId,
+      setFoldersWithPosts,
+    }),
     curFolder,
     SxConfirmIcons: SxIcon,
     onClickToggleFolderSpread: onClickToggleFolderSpread,

--- a/ganoverflow-next/src/app/chat/api/chat.ts
+++ b/ganoverflow-next/src/app/chat/api/chat.ts
@@ -1,4 +1,4 @@
-import { POST, PUT, PATCH } from "@/app/api/routeModule";
+import { POST, PUT, PATCH, DELETE } from "@/app/api/routeModule";
 import { GET } from "@/app/api/routeModule";
 
 import {
@@ -126,6 +126,58 @@ export const putFoldersByUser = async (
       return [];
     }
     throw new Error("Error updating folders - maybe unauthorized sideEffect");
+  }
+};
+
+//
+export const deleteChatpost = async ({
+  authData,
+  chatpostId,
+}: {
+  authData: IAuthData;
+  chatpostId: string;
+}): Promise<any> => {
+  if (authData === undefined) {
+    throw new Error("authData is undefined");
+  }
+
+  try {
+    const updatedFolders = await DELETE({
+      API: chatPostAPI,
+      endPoint: "",
+      params: chatpostId,
+      body: { userId: authData.userId },
+      authHeaders: GenerateAuthHeader(authData),
+    });
+
+    return updatedFolders.data;
+  } catch (error: any) {
+    throw new Error(`Failed to delete chatpost: ${error.message}`);
+  }
+};
+
+export const deleteChatpostsByFolder = async ({
+  authData,
+  folderId,
+}: {
+  authData: IAuthData;
+  folderId: IFolderWithPostsDTO["folderId"];
+}) => {
+  if (authData === undefined) {
+    alert("authData is undefined");
+    return [];
+  }
+
+  try {
+    const updatedFolders = await DELETE({
+      API: chatPostAPI,
+      endPoint: "removeAllByFolderId",
+      body: { folderId, userId: authData.userId },
+      authHeaders: GenerateAuthHeader(authData),
+    });
+    return updatedFolders.data;
+  } catch (error: any) {
+    throw new Error(`Failed to delete chatposts: ${error.message}`);
   }
 };
 


### PR DESCRIPTION
@hongregii 

#73 & https://github.com/modulersYJ/ganoverflow-back/issues/51 이슈 관련 작업입니다!

양 케이스 모두, setFolder를 수행에 따른 부수효과인 useEffect의 putFolders 요청에 의존하여 단순히 foldersData만 변경하던 것을, 각각에 해당하는 Delete 요청 라우터로 보내 chatposts & user.folders 양측에 올바르게 삭제(chatposts의 경우 delYn = 'Y')처리하도록 수정하였습니다!

관련 백엔드 PR : https://github.com/modulersYJ/ganoverflow-back/pull/58

<br>

---

<br>

### 0. 공통
- routeModule에서 REQUEST에 `DELETE` 요청 함수 확장

<br><br>

### 1. 사이드바에서 특정 chatpost 제거 관련
- `deleteChatpost` 요청 함수 구현
- 기존: setFolder
- getHandleDeleteChatpost의 핸들러를 수정: `deleteChatpost` 요청 & 반환받은 `updatedFolders`를 foldersData 상태에 갱신

<br><br>

### 2. 사이드바에서 폴더 제거 & 하위 포스트 제거 관련
- `deleteChatpostsByFolder` 요청 함수 구현

- `getDeleteFolderHandler`의 반환 핸들러가 ``deleteChatpostsByFolder`에 요청 및 반환받은 updatedFolder로 foldersData 갱신하도록 수정

<br><br>