### PR TITLE
hotfix: socialLogin 버튼 텍스트 중 앞 단어 3글자로 통일

### DIFF
--- a/ganoverflow-next/src/components/ui/Accounts/SocialLoginButton.tsx
+++ b/ganoverflow-next/src/components/ui/Accounts/SocialLoginButton.tsx
@@ -13,8 +13,8 @@ const SocialLoginButton: React.FC<Props> = ({ provider }) => {
   };
 
   const labels = {
-    kakao: "카카오로 로그인",
-    naver: "네이버로 로그인",
+    kakao: "카카오 로그인",
+    naver: "네이버 로그인",
     google: "구글로 로그인",
   };
 


### PR DESCRIPTION
뷰포트가 넓은 화면에 대해 아래와 같은 스타일 문제를 식별하여 핫픽스합니다.
![image](https://github.com/modulersYJ/ganoverflow-front/assets/65459616/3091d7d9-43c2-41d9-8bab-41252b1c4d35)
