### PR TITLE
feat-loginModal: 게시판 - LoginBoxModal 위치를 헤더로 변경 & 게시판 PDP에 적용 등

### DIFF
--- a/ganoverflow-next/src/app/accounts/login/LoginBoxModal.tsx
+++ b/ganoverflow-next/src/app/accounts/login/LoginBoxModal.tsx
@@ -6,8 +6,8 @@ export const LoginBoxModal = () => {
   const setIsSigned = useSetRecoilState(isSignedState);
 
   return (
-    <div className="LoginBoxModal z-30 fixed inset-0 flex justify-center items-center">
-      <div className="z-30 relative max-w-lg animate-popIn origin-bottom">
+    <div className="LoginBoxModal z-40 fixed inset-0 flex justify-center items-center">
+      <div className="z-40 relative max-w-lg animate-popIn origin-bottom">
         <LoginBox modalType />
       </div>
       <div

--- a/ganoverflow-next/src/app/accounts/my-page/page.tsx
+++ b/ganoverflow-next/src/app/accounts/my-page/page.tsx
@@ -2,8 +2,20 @@
 import Link from "next/link";
 import { getMypageData } from "./api/mypage";
 import { useEffect, useState } from "react";
+import { useSignedCheck } from "@/hooks/useSignedCheck";
+import { TIsSigned, isSignedState } from "@/atoms/sign";
+import { useRecoilState, useRecoilValue } from "recoil";
+import { useRouter } from "next/navigation";
 
 export default function Mypage() {
+  const isSigned = useRecoilValue(isSignedState);
+  const router = useRouter();
+  useEffect(() => {
+    if (isSigned !== TIsSigned.T) {
+      router.push("/accounts/login");
+    }
+  }, [isSigned]);
+
   const [mypageData, setMyPageData] = useState({
     hi: "dd",
     myPosts: [

--- a/ganoverflow-next/src/app/chat/ChatMain/index.tsx
+++ b/ganoverflow-next/src/app/chat/ChatMain/index.tsx
@@ -22,7 +22,6 @@ const ChatMain = ({ onClickNewChatBtn, scrollRef }: IChatMainProps) => {
 
   return (
     <div className="flex flex-col h-full ">
-      {isSigned === TIsSigned.F && <LoginBoxModal />}
       {isModalOpen && (
         <SaveChatModal
           categories={categories}

--- a/ganoverflow-next/src/app/chat/page.tsx
+++ b/ganoverflow-next/src/app/chat/page.tsx
@@ -34,7 +34,6 @@ export default function ChatPage() {
   useEffect(() => {
     console.log("loadChatStatus 초기화");
     setLoadChatStatus({ status: TLoadChatStatus.F, loadedMeta: undefined });
-    setIsSigned(TIsSigned.unknown);
   }, []);
 
   // foldersData - case 1) - accessToken 관리체계 리팩 이후 필요한지 의문(일단킵)

--- a/ganoverflow-next/src/app/layout.tsx
+++ b/ganoverflow-next/src/app/layout.tsx
@@ -12,7 +12,12 @@ import { logout } from "./accounts/login/api/login";
 import "@/styles/globals.css";
 import { Inter } from "next/font/google";
 
-import { RecoilRoot, useRecoilState, useSetRecoilState } from "recoil";
+import {
+  RecoilRoot,
+  useRecoilState,
+  useRecoilValue,
+  useSetRecoilState,
+} from "recoil";
 import { userState } from "@/atoms/user";
 import { getSessionStorageItem } from "@/utils/common/sessionStorage";
 import { foldersWithChatpostsState } from "@/atoms/folder";
@@ -25,6 +30,8 @@ import {
   questionInputState,
 } from "@/atoms/chat";
 import { setAccessToken } from "./api/jwt";
+import { LoginBoxModal } from "./accounts/login/LoginBoxModal";
+import { TIsSigned, isSignedState } from "@/atoms/sign";
 
 const siteTitle = "최고의 머시깽이, GanOverflow";
 const siteDescription = "Gan Overflow는 ...입니당. 최고의 경험을 누려보세요!";
@@ -100,6 +107,8 @@ const Header = ({
   toggleDarkMode: () => void;
   isDarkMode: boolean;
 }): JSX.Element => {
+  const [isSigned, setIsSigned] = useRecoilState(isSignedState);
+
   const [isOffCanvasOpen, setIsOffCanvasOpen] = useState(false);
   const [user, setUser] = useRecoilState(userState);
 
@@ -112,6 +121,7 @@ const Header = ({
 
   const onClickSetLogout = async () => {
     setUser(null);
+    setIsSigned(TIsSigned.unknown);
   };
   console.log("userData: ", user);
 
@@ -142,6 +152,7 @@ const Header = ({
 
   return (
     <header>
+      {isSigned === TIsSigned.F && <LoginBoxModal />}
       <nav className="header-nav shadow-headerBox fixed w-full top-0 z-50">
         <div className="mx-auto px-6 py-1 flex justify-between">
           <div className="flex items-center col-span-1">

--- a/ganoverflow-next/src/app/posts/[chatPostId]/components/comments.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/components/comments.tsx
@@ -1,24 +1,20 @@
 "use client";
 
 import React, { ChangeEvent, useEffect, useState } from "react";
-import { getComments, postComment } from "../../api/chatposts";
+import { postComment } from "../../api/chatposts";
 import { useRouter } from "next/navigation";
 import { parseDate, parseDateWithSeconds } from "@/utils/parseDate";
+import { useSignedCheck } from "@/hooks/useSignedCheck";
 
 export function CommentBox({
   chatPostId,
   comments,
 }: {
   chatPostId: string;
-  comments: {
-    commentId: number;
-    content: string;
-    createdAt: string;
-    delYn: string;
-    user: { username: string; nickname: string };
-  }[];
+  comments: TComments;
 }) {
-  console.log("🚀 ~ file: comments.tsx:22 ~ comments:", comments);
+  const checkUserSigned = useSignedCheck();
+
   const router = useRouter();
   const commentCount = comments?.length;
   const [commentData, setCommentData] = useState("");
@@ -29,26 +25,20 @@ export function CommentBox({
   };
 
   const handleSubmit = async () => {
+    if (!checkUserSigned()) return;
+
     if (commentData === "") {
       alert("댓글을 입력하세요");
       return;
     }
 
-    try {
-      const res = await postComment({ content: commentData }, chatPostId);
-      if (res.status === 201) {
-        setCommentData("");
-        alert("등록이 완료되었습니다.");
-        router.refresh();
-      } else {
-        console.log("res ", res);
-        alert("등록 실패");
-      }
-    } catch (e: any) {
-      console.log(e);
-      if (e?.response?.status === 401) {
-        alert("로그인이 필요합니다");
-      }
+    const res = await postComment({ content: commentData }, chatPostId);
+    if (res.status === 201) {
+      setCommentData("");
+      router.refresh();
+    } else {
+      console.log("등록 실패: ", res);
+      
     }
   };
 
@@ -102,3 +92,11 @@ export function CommentBox({
     </>
   );
 }
+
+export type TComments = {
+  commentId: number;
+  content: string;
+  createdAt: string;
+  delYn: string;
+  user: { username: string; nickname: string };
+}[];

--- a/ganoverflow-next/src/app/posts/api/chatposts.ts
+++ b/ganoverflow-next/src/app/posts/api/chatposts.ts
@@ -17,13 +17,20 @@ export const postComment = async (
   commentData: { content: string },
   chatPostId: string
 ) => {
-  const res = await POST({
-    API: commentAPI,
-    endPoint: `${chatPostId}`,
-    body: commentData,
-    isAuth: true,
-  });
-  return res;
+  try {
+    const res = await POST({
+      API: commentAPI,
+      endPoint: `${chatPostId}`,
+      body: commentData,
+      isAuth: true,
+    });
+    return res;
+  } catch (error: any) {
+    if (error.response && error.response.status === 401) {
+      console.log("Error 401: 로그인 하세요!");
+      return [];
+    }
+  }
 };
 
 export const getComments = async (chatPostId: string) => {
@@ -47,11 +54,18 @@ export const postStar = async ({
     chatPostId: chatPostId,
     like: value,
   };
-  const res = await POST({
-    API: starAPI,
-    endPoint: "",
-    isAuth: true,
-    body,
-  });
-  return res;
+  try {
+    const res = await POST({
+      API: starAPI,
+      endPoint: "",
+      isAuth: true,
+      body,
+    });
+    return res;
+  } catch (error: any) {
+    if (error.response && error.response.status === 401) {
+      console.log("Error 401: 로그인 하세요!");
+      return [];
+    }
+  }
 };


### PR DESCRIPTION
@hongregii 로그인모달 사용법 개선 & 게시판 커멘트,좋아요에 적용했습니다!

- #81 이슈 
- #86 PR 
- #92 PR 
관련 내용입니다.
---


### LoginBoxModal 위치를 헤더로 변경
#### 기존 모달로그인 사용법 : 
각각의 LoginBoxModal이 필요한 컴포넌트마다 삽입 & `useSignedCheck();` 반환 함수를 호출

#### 변경 후 모달로그인 사용법: 
헤더에 LoginBoxModal 삽입하여 앱 전역에서 공통사용, `useSignedCheck();` 훅이 반환하는 함수만 필요한 곳에 호출하여 사용할 수 있도록 수정

<br>

### 게시판 PDP에 적용 
- 게시판의 Like, Comment 각각 제출 핸들러에서 `useSignedCheck()();` 호출하여 모달로그인 추가

- Like, Comment 제출 요청함수의 401에러에 대해 에러를 던지지 않고 console.log()로 출력하여 정상케이스 처리

<br>

### 기타)
- 마이페이지에서 `isSigned` 상태 감지, 비로그인 시 로그인페이지로 리다이렉트
- 로그아웃 시 `setIsSigned(TIsSigned.unknown);` 처리
- 챗페이지 진입 시 불필요하게 isSigned 상태를 unknown으로 초기화하던 로직 제거